### PR TITLE
[FEAT] Allow matching empty Description & Location event properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ calendars:
         match:
           summary:
             prefix: "Canceled: "
-      - description: "Remove optional events"
+      - description: "Remove events without descriptions"
         remove: true
         match:
-          summary:
-            prefix: "[Optional]"
+          description:
+            empty: true
       - description: "Remove public holidays"
         remove: true
         match:
@@ -168,6 +168,7 @@ Each filter can specify match conditions against the following event properties:
 
 These match conditions are available for a string value:
 
+* `empty` - if `true`, property must be absent or empty
 * `contains` - property must contain this value
 * `prefix` - property must start with this value
 * `suffix` - property must end with this value

--- a/calendar.go
+++ b/calendar.go
@@ -154,7 +154,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 			return false // event doesn't match
 		}
 	}
-
+	
 	// Check Description filters against VEvent
 	if filter.Match.Location.hasConditions() {
 		eventLocation := event.GetProperty(ics.ComponentPropertyLocation)
@@ -202,13 +202,9 @@ type EventMatchRules struct {
 	Location    StringMatchRule `yaml:"location"`
 }
 
-type NullMatchRule struct {
-	Null bool `yaml:"empty"`
-}
-
 // StringMatchRule defines match rules for VEvent properties with string values
 type StringMatchRule struct {
-	NullMatchRule
+	Null       bool   `yaml:"empty"`
 	Contains   string `yaml:"contains"`
 	Prefix     string `yaml:"prefix"`
 	Suffix     string `yaml:"suffix"`
@@ -217,7 +213,8 @@ type StringMatchRule struct {
 
 // Returns true if StringMatchRule has any conditions
 func (smr StringMatchRule) hasConditions() bool {
-	return smr.Contains != "" ||
+	return smr.Null ||
+	    smr.Contains != "" ||
 		smr.Prefix != "" ||
 		smr.Suffix != "" ||
 		smr.RegexMatch != ""

--- a/calendar.go
+++ b/calendar.go
@@ -141,11 +141,12 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 	// Check Description filters against VEvent
 	if filter.Match.Description.hasConditions() {
 		eventDescription := event.GetProperty(ics.ComponentPropertyDescription)
+		var eventDescriptionValue string
 		if eventDescription == nil {
 			slog.Debug("Event has no Description, but continuing checking filters", "event_summary", eventSummary.Value, "filter", filter.Description)
-			eventDescriptionValue := ""
+			eventDescriptionValue = ""
 		} else {
-			eventDescriptionValue := eventDescription.Value
+			eventDescriptionValue = eventDescription.Value
 		}
 
 		if !filter.Match.Description.matchesString(eventDescriptionValue) {
@@ -157,11 +158,12 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 	// Check Description filters against VEvent
 	if filter.Match.Location.hasConditions() {
 		eventLocation := event.GetProperty(ics.ComponentPropertyLocation)
+		var eventLocationValue string
 		if eventLocation == nil {
 			slog.Warn("Event has no Location, but continuing checking filters", "event_summary", eventSummary.Value, "filter", filter.Description)
-			eventLocationValue := ""
+			eventLocationValue = ""
 		} else {
-			eventLocationValue := eventLocation.Value
+			eventLocationValue = eventLocation.Value
 		}
 		if !filter.Match.Location.matchesString(eventLocationValue) {
 			slog.Debug("Event Location does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)

--- a/calendar.go
+++ b/calendar.go
@@ -143,7 +143,6 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 		eventDescription := event.GetProperty(ics.ComponentPropertyDescription)
 		var eventDescriptionValue string
 		if eventDescription == nil {
-			slog.Debug("Event has no Description, but continuing checking filters", "event_summary", eventSummary.Value, "filter", filter.Description)
 			eventDescriptionValue = ""
 		} else {
 			eventDescriptionValue = eventDescription.Value
@@ -160,7 +159,6 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 		eventLocation := event.GetProperty(ics.ComponentPropertyLocation)
 		var eventLocationValue string
 		if eventLocation == nil {
-			slog.Warn("Event has no Location, but continuing checking filters", "event_summary", eventSummary.Value, "filter", filter.Description)
 			eventLocationValue = ""
 		} else {
 			eventLocationValue = eventLocation.Value


### PR DESCRIPTION
Allow using `empty: true` as a filter for matching events, in the same context as `contains`, `prefix`, `suffix`, and `regex`. A change to matching was needed as events with missing Description/Location properties get skipped. This new option would provide the same functionality as a regex expression to match empty strings, but provides more efficient processing and is simpler to use.