### PR TITLE
Replace global unsafe setting with public calendar setting (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ calendars:
   # basic example
   - name: example # used as slug in URL - e.g. ical-filter-proxy:8080/calendars/example/feed?token=changeme
     publish_name: "My Calendar" # the published name of the calendar - uses upstream value if this line is skipped
-    token: "changeme" # token used to pull iCal feed - authentication is disabled when blank
+    token: "changeme" # optional - token must be used to pull iCal feed if defined
+    public: false # optional - must be true if token is blank or not defined
     feed_url: "https://my-upstream-calendar.url/feed.ics" # URL for the upstream iCal feed
     filters: # optional - if no filters defined the upstream calendar is proxied as parsed
       - description: "Remove an event based on a regex"
@@ -99,7 +100,6 @@ calendars:
 
   # example: removing noise from an Office 365 calendar
   - name: outlook
-    publish_name: "My Outlook Calendar" # the published name of the calendar - uses upstream value if this line is skipped
     token: "changeme"
     feed_url: "https://outlook.office365.com/owa/calendar/.../reachcalendar.ics"
     filters:
@@ -134,8 +134,6 @@ calendars:
             replace: "On-Call" # replace the event summary (title)
       - description: "Remove all other events"
         remove: true
-
-unsafe: false # optional - must be enabled if any calendars do not have a token
 ```
 
 ### Filters

--- a/calendar.go
+++ b/calendar.go
@@ -18,6 +18,7 @@ import (
 type CalendarConfig struct {
 	Name        string   `yaml:"name"`
 	PublishName string   `yaml:"publish_name"`
+	Public      bool     `yaml:"public"`
 	Token       string   `yaml:"token"`
 	TokenFile   string   `yaml:"token_file"`
 	FeedURL     string   `yaml:"feed_url"`

--- a/main.go
+++ b/main.go
@@ -16,8 +16,7 @@ var version = "development"
 
 // this struct used to parse config.yaml
 type Config struct {
-	Calendars   []CalendarConfig `yaml:"calendars"`
-	AllowUnsafe bool             `yaml:"unsafe"`
+	Calendars []CalendarConfig `yaml:"calendars"`
 }
 
 // This function loads the configuration file and does some basic validation
@@ -70,13 +69,13 @@ func (config *Config) LoadConfig(file string) bool {
 		}
 
 		// Check to see if auth is disabled (token not set)
-		// If so print a warning message and make sure unsafe is enabled in config
-		if len(calendarConfig.Token) == 0 {
-			slog.Warn("Calendar has no token set. Authentication will be disabled", "calendar", calendarConfig.Name)
-			if !config.AllowUnsafe {
-				slog.Error("Calendar cannot have authentication disabled without unsafe optionenabled in the configuration", "calendar", calendarConfig.Name)
+		// If so print a warning message and make sure public is enabled in config
+		if calendarConfig.Token == "" {
+			if !calendarConfig.Public {
+				slog.Error("Calendar cannot have authentication disabled without public option enabled in the configuration", "calendar", calendarConfig.Name)
 				return false
 			}
+			slog.Warn("Calendar has no token set. Authentication will be disabled", "calendar", calendarConfig.Name)
 		}
 
 		// Print a warning if the calendar has no filters


### PR DESCRIPTION
Replaces the existing global `unsafe` option with a `public` setting per-calendar.
Breaking change requires config update if using calendars with no `token` set and the global `unsafe` enabled