### PR TITLE
Add support for prefix and suffix transformations

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -202,18 +202,47 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 func (filter Filter) transformEvent(event *ics.VEvent) {
 
 	// Summary transformations
+	eventSummary := event.GetProperty(ics.ComponentPropertySummary)
+	var eventSummaryValue string
+	if eventSummary == nil {
+		eventSummaryValue = ""
+	} else {
+		eventSummaryValue = eventSummary.Value
+	}
 	if filter.Transform.Summary.Remove {
 		event.SetSummary("")
-	} else if filter.Transform.Summary.Replace != "" {
+	}
+	if filter.Transform.Summary.Replace != "" {
 		event.SetSummary(filter.Transform.Summary.Replace)
+	}
+	if filter.Transform.Summary.Prefix != "" {
+		event.SetSummary(filter.Transform.Summary.Prefix + eventSummaryValue)
+	}
+	if filter.Transform.Summary.Suffix != "" {
+		event.SetSummary(eventSummaryValue + filter.Transform.Summary.Suffix)
 	}
 
 	// Description transformations
+	eventDescription := event.GetProperty(ics.ComponentPropertyDescription)
+	var eventDescriptionValue string
+	if eventDescription == nil {
+		eventDescriptionValue = ""
+	} else {
+		eventDescriptionValue = eventDescription.Value
+	}
 	if filter.Transform.Description.Remove {
 		event.SetDescription("")
-	} else if filter.Transform.Description.Replace != "" {
+	}
+	if filter.Transform.Description.Replace != "" {
 		event.SetDescription(filter.Transform.Description.Replace)
 	}
+	if filter.Transform.Description.Prefix != "" {
+		event.SetDescription(filter.Transform.Description.Prefix + eventDescriptionValue)
+	}
+	if filter.Transform.Description.Suffix != "" {
+		event.SetDescription(eventDescriptionValue + filter.Transform.Description.Suffix)
+	}
+
 
 	// Location transformations
 	if filter.Transform.Location.Remove {
@@ -307,4 +336,6 @@ type EventTransformRules struct {
 type StringTransformRule struct {
 	Replace string `yaml:"replace"`
 	Remove  bool   `yaml:"remove"`
+	Prefix  string `yaml:"prefix"`
+	Suffix  string `yaml:"suffix"`
 }


### PR DESCRIPTION
I deployed this yesterday to work around a limitation in a DAKboard iCal feed (no event colors), and it worked wonderfully. But then I decided I wanted to transparently add a few emojis to some event titles, and I quickly ran into situations where being able to either remove or completely replace the existing titles (summaries) was too limited. To fix this, I added `prefix` and `suffix` options to the `transform` code, so you can leave the original title intact and just add something to the beginning and/or end.

I've only tested it in my own simple/limited instance, but it works great for me, so I figured I'd send the feature back upstream. Thanks for a great little tool!