### PR TITLE
harden upstream calendar fetching

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,30 @@
+name: go-test
+
+on:
+  push:
+    branches:
+      - "*"
+    paths:
+      - go.mod
+      - go.sum
+      - "*.go"
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+      - "*.go"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: go test
+        run: go test ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,4 +29,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.60
+          version: v2.12.2

--- a/calendar.go
+++ b/calendar.go
@@ -3,22 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"regexp"
 	"strings"
-	"time"
 
 	ics "github.com/arran4/golang-ical"
 )
-
-const maxCalendarBytes = 10 << 20
-
-var upstreamHTTPClient = &http.Client{
-	Timeout: 15 * time.Second,
-}
 
 // All structs defined in this file are used to unmarshall yaml configuration and
 // provide helper functions that are used to fetch and filter events
@@ -40,29 +30,9 @@ func (calendarConfig CalendarConfig) fetch(ctx context.Context) ([]byte, error) 
 
 	// get the iCal feed
 	slog.Debug("Fetching iCal feed", "url", calendarConfig.FeedURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, calendarConfig.FeedURL, nil)
+	feedData, err := fetchUpstreamCalendar(ctx, calendarConfig.FeedURL)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("User-Agent", "ical-filter-proxy/"+version)
-	req.Header.Set("Accept", "text/calendar, text/plain;q=0.8, */*;q=0.1")
-
-	resp, err := upstreamHTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("upstream returned %s", resp.Status)
-	}
-
-	feedData, err := io.ReadAll(io.LimitReader(resp.Body, maxCalendarBytes+1))
-	if err != nil {
-		return nil, err
-	}
-	if len(feedData) > maxCalendarBytes {
-		return nil, fmt.Errorf("upstream calendar exceeds %d bytes", maxCalendarBytes)
 	}
 
 	// parse calendar

--- a/calendar.go
+++ b/calendar.go
@@ -2,14 +2,23 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	ics "github.com/arran4/golang-ical"
 )
+
+const maxCalendarBytes = 10 << 20
+
+var upstreamHTTPClient = &http.Client{
+	Timeout: 15 * time.Second,
+}
 
 // All structs defined in this file are used to unmarshall yaml configuration and
 // provide helper functions that are used to fetch and filter events
@@ -27,19 +36,33 @@ type CalendarConfig struct {
 }
 
 // Downloads iCal feed from the URL and applies filtering rules
-func (calendarConfig CalendarConfig) fetch() ([]byte, error) {
+func (calendarConfig CalendarConfig) fetch(ctx context.Context) ([]byte, error) {
 
 	// get the iCal feed
 	slog.Debug("Fetching iCal feed", "url", calendarConfig.FeedURL)
-	resp, err := http.Get(calendarConfig.FeedURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, calendarConfig.FeedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "ical-filter-proxy/"+version)
+	req.Header.Set("Accept", "text/calendar, text/plain;q=0.8, */*;q=0.1")
+
+	resp, err := upstreamHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	feedData, err := io.ReadAll(resp.Body)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("upstream returned %s", resp.Status)
+	}
+
+	feedData, err := io.ReadAll(io.LimitReader(resp.Body, maxCalendarBytes+1))
 	if err != nil {
 		return nil, err
+	}
+	if len(feedData) > maxCalendarBytes {
+		return nil, fmt.Errorf("upstream calendar exceeds %d bytes", maxCalendarBytes)
 	}
 
 	// parse calendar
@@ -242,7 +265,6 @@ func (filter Filter) transformEvent(event *ics.VEvent) {
 	if filter.Transform.Description.Suffix != "" {
 		event.SetDescription(eventDescriptionValue + filter.Transform.Description.Suffix)
 	}
-
 
 	// Location transformations
 	if filter.Transform.Location.Remove {

--- a/main.go
+++ b/main.go
@@ -175,10 +175,10 @@ func main() {
 			}
 
 			// fetch and filter upstream calendar
-			feed, err := calendarConfig.fetch()
+			feed, err := calendarConfig.fetch(r.Context())
 			if err != nil {
 				slog.Error("Error fetching and filtering feed", "error", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				http.Error(w, "Bad Gateway", http.StatusBadGateway)
 				return
 			}
 

--- a/upstream.go
+++ b/upstream.go
@@ -26,7 +26,9 @@ func fetchUpstreamCalendar(ctx context.Context, feedURL string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("upstream returned %s", resp.Status)

--- a/upstream.go
+++ b/upstream.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const maxCalendarBytes = 10 << 20
+
+var upstreamHTTPClient = &http.Client{
+	Timeout: 15 * time.Second,
+}
+
+func fetchUpstreamCalendar(ctx context.Context, feedURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "ical-filter-proxy/"+version)
+	req.Header.Set("Accept", "text/calendar, text/plain;q=0.8, */*;q=0.1")
+
+	resp, err := upstreamHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("upstream returned %s", resp.Status)
+	}
+
+	feedData, err := io.ReadAll(io.LimitReader(resp.Body, maxCalendarBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(feedData) > maxCalendarBytes {
+		return nil, fmt.Errorf("upstream calendar exceeds %d bytes", maxCalendarBytes)
+	}
+
+	return feedData, nil
+}

--- a/upstream_test.go
+++ b/upstream_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchUpstreamCalendarSuccess(t *testing.T) {
+	body := "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != "ical-filter-proxy/"+version {
+			t.Fatalf("User-Agent = %q, want %q", got, "ical-filter-proxy/"+version)
+		}
+		if got := r.Header.Get("Accept"); got != "text/calendar, text/plain;q=0.8, */*;q=0.1" {
+			t.Fatalf("Accept = %q, want text/calendar preference", got)
+		}
+		w.Header().Set("Content-Type", "text/calendar")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	got, err := fetchUpstreamCalendar(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchUpstreamCalendar returned error: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body = %q, want %q", string(got), body)
+	}
+}
+
+func TestFetchUpstreamCalendarRejectsNonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err := fetchUpstreamCalendar(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("fetchUpstreamCalendar returned nil error")
+	}
+	if !strings.Contains(err.Error(), "upstream returned 503 Service Unavailable") {
+		t.Fatalf("error = %q, want upstream status", err.Error())
+	}
+}
+
+func TestFetchUpstreamCalendarRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("x"), maxCalendarBytes+1))
+	}))
+	defer server.Close()
+
+	_, err := fetchUpstreamCalendar(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("fetchUpstreamCalendar returned nil error")
+	}
+	if !strings.Contains(err.Error(), "upstream calendar exceeds") {
+		t.Fatalf("error = %q, want size limit error", err.Error())
+	}
+}
+
+func TestFetchUpstreamCalendarUsesContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not receive request for canceled context")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := fetchUpstreamCalendar(ctx, server.URL)
+	if err == nil {
+		t.Fatal("fetchUpstreamCalendar returned nil error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
  - Use a shared `http.Client` with 15s timeout
  - Pass incoming request context into upstream fetches so cancellation propagates
  - Add `User-Agent` and `Accept` headers for upstream requests
  - Reject non-2xx upstream responses before parsing
  - Limit upstream calendar body to 10 MiB
  - Return 502 for upstream fetch/filter/parse fail