### PR TITLE
add nix flake lint, update nix configs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,43 @@
+name: nix
+
+on:
+  push:
+    branches:
+      - "*"
+    paths:
+      - ".github/workflows/nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "go.mod"
+      - "go.sum"
+      - "service.nix"
+      - "*.go"
+  pull_request:
+    paths:
+      - ".github/workflows/nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "go.mod"
+      - "go.sum"
+      - "service.nix"
+      - "*.go"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    name: flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Check flake
+        run: nix flake check --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     flake-utils,
   }: let
     # NixOS module that works across all systems
-    nixosModule = import ./service.nix;
+    nixosModule = args: import ./service.nix (args // {inherit self;});
 
     # Overlay to make ical-filter-proxy available in nixpkgs
     overlay = final: prev: {

--- a/service.nix
+++ b/service.nix
@@ -2,18 +2,23 @@
   config,
   lib,
   pkgs,
+  self ? null,
   ...
 }:
 with lib; let
   cfg = config.services.ical-filter-proxy;
+  defaultPackage =
+    if self != null
+    then self.packages.${pkgs.stdenv.hostPlatform.system}.default
+    else pkgs.ical-filter-proxy;
 in {
   options.services.ical-filter-proxy = {
     enable = mkEnableOption "iCal Filter Proxy service";
 
     package = mkOption {
       type = types.package;
-      default = pkgs.ical-filter-proxy;
-      defaultText = literalExpression "pkgs.ical-filter-proxy";
+      default = defaultPackage;
+      defaultText = literalExpression "self.packages.${pkgs.stdenv.hostPlatform.system}.default";
       description = "The ical-filter-proxy package to use.";
     };
 
@@ -62,7 +67,7 @@ in {
                   description = "Authentication token for accessing the calendar feed.";
                 };
                 token_file = mkOption {
-                  type = types.nullOr types.path;
+                  type = types.nullOr types.str;
                   default = null;
                   description = "Path to file containing the authentication token.";
                 };
@@ -77,7 +82,7 @@ in {
                   description = "URL of the upstream iCal feed.";
                 };
                 feed_url_file = mkOption {
-                  type = types.nullOr types.path;
+                  type = types.nullOr types.str;
                   default = null;
                   description = "Path to file containing the feed URL.";
                 };
@@ -254,6 +259,16 @@ in {
                                     default = null;
                                     description = "Remove summary (set to empty string).";
                                   };
+                                  prefix = mkOption {
+                                    type = types.nullOr types.str;
+                                    default = null;
+                                    description = "Prefix summary with this string.";
+                                  };
+                                  suffix = mkOption {
+                                    type = types.nullOr types.str;
+                                    default = null;
+                                    description = "Suffix summary with this string.";
+                                  };
                                 };
                               });
                               default = null;
@@ -289,6 +304,16 @@ in {
                                     type = types.nullOr types.bool;
                                     default = null;
                                     description = "Remove description (set to empty string).";
+                                  };
+                                  prefix = mkOption {
+                                    type = types.nullOr types.str;
+                                    default = null;
+                                    description = "Prefix description with this string.";
+                                  };
+                                  suffix = mkOption {
+                                    type = types.nullOr types.str;
+                                    default = null;
+                                    description = "Suffix description with this string.";
                                   };
                                 };
                               });


### PR DESCRIPTION
- add nix ci (nix flake check)
- update nix configs:
  - default now points at the flake package via self
  - `token_file` and `feed_url_file` as strings instead of nix store paths
  - added summary/description prefix/suffix transforms to config