### PR TITLE
add actionlint ci and renovate for actions updates

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,6 +23,14 @@ jobs:
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_VERSION: 1.7.12
     steps:
       - uses: actions/checkout@v7
-      - uses: rhysd/actionlint@v1
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}" "${RUNNER_TEMP}"
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,28 @@
+name: actionlint
+
+on:
+  push:
+    branches:
+      - "*"
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: rhysd/actionlint@v1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,7 +59,7 @@ jobs:
             version=${short_sha}
           fi
 
-          echo "VERSION=${version}" >> $GITHUB_ENV
+          echo "VERSION=${version}" >> "$GITHUB_ENV"
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: stable
       - name: Check formatting
         run: |
-          files="$(gofmt -l *.go)"
+          files="$(gofmt -l ./*.go)"
           if [ -n "$files" ]; then
             echo "$files"
             exit 1

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,46 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "custom.regex",
+    "dockerfile",
+    "github-actions",
+    "gomod",
+    "nix"
+  ],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group actionlint with GitHub Actions updates",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "rhysd/actionlint"
+      ],
+      "groupName": "github actions",
+      "groupSlug": "github-actions"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update actionlint binary version",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/actionlint\\.yml$/"
+      ],
+      "matchStrings": [
+        "ACTIONLINT_VERSION:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "rhysd/actionlint",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ]
 }


### PR DESCRIPTION
- add actionlint ci for actions changes
- pin actionlint to 1.7.12
- fix shellcheck findings in existing workflows
- update renovate config:
  -  make managers explicit
  - add custom regex for ACTIONLINT_VERSION
  - group all actions updates into one PR