### PR TITLE
more security fixes and refactoring

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -28,7 +28,7 @@ type CalendarConfig struct {
 func (calendarConfig CalendarConfig) fetch(ctx context.Context) ([]byte, error) {
 
 	// get the iCal feed
-	slog.Debug("Fetching iCal feed", "url", calendarConfig.FeedURL)
+	slog.Debug("Fetching iCal feed", "url", redactURL(calendarConfig.FeedURL))
 	feedData, err := fetchUpstreamCalendar(ctx, calendarConfig.FeedURL)
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -38,6 +38,11 @@ func (config *Config) LoadConfig(file string) bool {
 		// grab pointer so we can mutate values when loading from file
 		calendarConfig := &config.Calendars[i]
 
+		if calendarConfig.Public && (calendarConfig.Token != "" || calendarConfig.TokenFile != "") {
+			slog.Error("Public calendar cannot define token or token_file", "calendar", calendarConfig.Name)
+			return false
+		}
+
 		// check if url should be loaded from file
 		if calendarConfig.FeedURLFile != "" {
 			calendarConfig.FeedURL, err = readSecretFile(calendarConfig.FeedURLFile)
@@ -62,14 +67,11 @@ func (config *Config) LoadConfig(file string) bool {
 			}
 		}
 
-		// Check to see if auth is disabled (token not set)
-		// If so print a warning message and make sure public is enabled in config
-		if calendarConfig.Token == "" {
-			if !calendarConfig.Public {
-				slog.Error("Calendar cannot have authentication disabled without public option enabled in the configuration", "calendar", calendarConfig.Name)
-				return false
-			}
+		if calendarConfig.Public {
 			slog.Warn("Calendar has no token set. Authentication will be disabled", "calendar", calendarConfig.Name)
+		} else if calendarConfig.Token == "" {
+			slog.Error("Private calendar must define token or token_file", "calendar", calendarConfig.Name)
+			return false
 		}
 
 		// Print a warning if the calendar has no filters

--- a/config_test.go
+++ b/config_test.go
@@ -57,6 +57,28 @@ calendars:
 			want: false,
 		},
 		{
+			name: "public calendar with token",
+			yaml: `
+calendars:
+  - name: public
+    public: true
+    token: secret
+    feed_url: https://example.com/feed.ics
+`,
+			want: false,
+		},
+		{
+			name: "public calendar with token_file",
+			yaml: `
+calendars:
+  - name: public
+    public: true
+    token_file: /run/secrets/token
+    feed_url: https://example.com/feed.ics
+`,
+			want: false,
+		},
+		{
 			name: "invalid yaml",
 			yaml: `
 calendars:

--- a/handler.go
+++ b/handler.go
@@ -7,6 +7,11 @@ import (
 	"net/http"
 )
 
+const (
+	calendarContentType = "text/calendar; charset=utf-8"
+	cacheControlHeader  = "no-store"
+)
+
 type calendarFetchFunc func(context.Context) ([]byte, error)
 
 func calendarFeedHandler(httpPath string, calendarConfig CalendarConfig) http.HandlerFunc {
@@ -15,6 +20,8 @@ func calendarFeedHandler(httpPath string, calendarConfig CalendarConfig) http.Ha
 
 func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig, fetch calendarFetchFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		setCommonResponseHeaders(w)
+
 		slog.Debug("Received request for calendar", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
 
 		if !calendarConfig.Public && !tokenMatches(r.URL.Query().Get("token"), calendarConfig.Token) {
@@ -32,7 +39,7 @@ func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig
 		}
 
 		// return calendar
-		w.Header().Set("Content-Type", "text/calendar")
+		w.Header().Set("Content-Type", calendarContentType)
 		_, err = w.Write(feed)
 		if err != nil {
 			slog.Error("Error writing response", "error", err)
@@ -42,6 +49,11 @@ func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig
 
 		slog.Info("Calendar request processed", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
 	}
+}
+
+func setCommonResponseHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", cacheControlHeader)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 func tokenMatches(token string, expectedToken string) bool {

--- a/handler.go
+++ b/handler.go
@@ -10,6 +10,7 @@ import (
 const (
 	calendarContentType = "text/calendar; charset=utf-8"
 	cacheControlHeader  = "no-store"
+	allowedMethods      = "GET, HEAD"
 )
 
 type calendarFetchFunc func(context.Context) ([]byte, error)
@@ -21,6 +22,12 @@ func calendarFeedHandler(calendarConfig CalendarConfig) http.HandlerFunc {
 func calendarFeedHandlerWithFetch(calendarConfig CalendarConfig, fetch calendarFetchFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setCommonResponseHeaders(w)
+
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", allowedMethods)
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
 
 		if !calendarConfig.Public && !tokenMatches(r.URL.Query().Get("token"), calendarConfig.Token) {
 			slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
@@ -38,6 +45,10 @@ func calendarFeedHandlerWithFetch(calendarConfig CalendarConfig, fetch calendarF
 
 		// return calendar
 		w.Header().Set("Content-Type", calendarContentType)
+		if r.Method == http.MethodHead {
+			return
+		}
+
 		_, err = w.Write(feed)
 		if err != nil {
 			slog.Error("Error writing response", "error", err)

--- a/handler.go
+++ b/handler.go
@@ -17,9 +17,7 @@ func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig
 	return func(w http.ResponseWriter, r *http.Request) {
 		slog.Debug("Received request for calendar", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
 
-		// validate token
-		token := r.URL.Query().Get("token")
-		if !tokenMatches(token, calendarConfig.Token) {
+		if !calendarConfig.Public && !tokenMatches(r.URL.Query().Get("token"), calendarConfig.Token) {
 			slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+)
+
+type calendarFetchFunc func(context.Context) ([]byte, error)
+
+func calendarFeedHandler(httpPath string, calendarConfig CalendarConfig) http.HandlerFunc {
+	return calendarFeedHandlerWithFetch(httpPath, calendarConfig, calendarConfig.fetch)
+}
+
+func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig, fetch calendarFetchFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slog.Debug("Received request for calendar", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
+
+		// validate token
+		token := r.URL.Query().Get("token")
+		if !tokenMatches(token, calendarConfig.Token) {
+			slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// fetch and filter upstream calendar
+		feed, err := fetch(r.Context())
+		if err != nil {
+			slog.Error("Error fetching and filtering feed", "error", err)
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+			return
+		}
+
+		// return calendar
+		w.Header().Set("Content-Type", "text/calendar")
+		_, err = w.Write(feed)
+		if err != nil {
+			slog.Error("Error writing response", "error", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		slog.Info("Calendar request processed", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
+	}
+}
+
+func tokenMatches(token string, expectedToken string) bool {
+	return subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1
+}

--- a/handler.go
+++ b/handler.go
@@ -14,15 +14,13 @@ const (
 
 type calendarFetchFunc func(context.Context) ([]byte, error)
 
-func calendarFeedHandler(httpPath string, calendarConfig CalendarConfig) http.HandlerFunc {
-	return calendarFeedHandlerWithFetch(httpPath, calendarConfig, calendarConfig.fetch)
+func calendarFeedHandler(calendarConfig CalendarConfig) http.HandlerFunc {
+	return calendarFeedHandlerWithFetch(calendarConfig, calendarConfig.fetch)
 }
 
-func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig, fetch calendarFetchFunc) http.HandlerFunc {
+func calendarFeedHandlerWithFetch(calendarConfig CalendarConfig, fetch calendarFetchFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setCommonResponseHeaders(w)
-
-		slog.Debug("Received request for calendar", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
 
 		if !calendarConfig.Public && !tokenMatches(r.URL.Query().Get("token"), calendarConfig.Token) {
 			slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
@@ -46,8 +44,6 @@ func calendarFeedHandlerWithFetch(httpPath string, calendarConfig CalendarConfig
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
-
-		slog.Info("Calendar request processed", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -100,6 +100,43 @@ func TestCalendarFeedHandlerSuccess(t *testing.T) {
 	}
 }
 
+func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{
+			name:   "no token",
+			target: "/calendars/public/feed",
+		},
+		{
+			name:   "wrong token",
+			target: "/calendars/public/feed?token=wrong",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := calendarFeedHandlerWithFetch(
+				"/calendars/public/feed",
+				CalendarConfig{Name: "public", Public: true},
+				func(context.Context) ([]byte, error) {
+					return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
+				},
+			)
+
+			req := testRequest(t, tt.target)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+			}
+		})
+	}
+}
+
 func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
 	handler := calendarFeedHandlerWithFetch(
 		"/calendars/private/feed",

--- a/handler_test.go
+++ b/handler_test.go
@@ -54,7 +54,6 @@ func TestTokenMatches(t *testing.T) {
 func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
 	fetchCalled := false
 	handler := calendarFeedHandlerWithFetch(
-		"/calendars/private/feed",
 		CalendarConfig{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			fetchCalled = true
@@ -78,7 +77,6 @@ func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
 
 func TestCalendarFeedHandlerSuccess(t *testing.T) {
 	handler := calendarFeedHandlerWithFetch(
-		"/calendars/private/feed",
 		CalendarConfig{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
@@ -120,7 +118,6 @@ func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := calendarFeedHandlerWithFetch(
-				"/calendars/public/feed",
 				CalendarConfig{Name: "public", Public: true},
 				func(context.Context) ([]byte, error) {
 					return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
@@ -141,7 +138,6 @@ func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
 
 func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
 	handler := calendarFeedHandlerWithFetch(
-		"/calendars/private/feed",
 		CalendarConfig{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			return nil, errors.New("upstream failed")

--- a/handler_test.go
+++ b/handler_test.go
@@ -100,6 +100,58 @@ func TestCalendarFeedHandlerSuccess(t *testing.T) {
 	}
 }
 
+func TestCalendarFeedHandlerHeadSuccess(t *testing.T) {
+	handler := calendarFeedHandlerWithFetch(
+		CalendarConfig{Name: "private", Token: "secret"},
+		func(context.Context) ([]byte, error) {
+			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
+		},
+	)
+
+	req := testRequestWithMethod(t, http.MethodHead, "/calendars/private/feed?token=secret")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	assertCommonResponseHeaders(t, rr)
+	if got := rr.Header().Get("Content-Type"); got != calendarContentType {
+		t.Fatalf("Content-Type = %q, want %q", got, calendarContentType)
+	}
+	if got := rr.Body.String(); got != "" {
+		t.Fatalf("body = %q, want empty body", got)
+	}
+}
+
+func TestCalendarFeedHandlerMethodNotAllowed(t *testing.T) {
+	fetchCalled := false
+	handler := calendarFeedHandlerWithFetch(
+		CalendarConfig{Name: "private", Token: "secret"},
+		func(context.Context) ([]byte, error) {
+			fetchCalled = true
+			return []byte("should not be called"), nil
+		},
+	)
+
+	req := testRequestWithMethod(t, http.MethodPost, "/calendars/private/feed?token=secret")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
+	}
+	assertCommonResponseHeaders(t, rr)
+	if got := rr.Header().Get("Allow"); got != allowedMethods {
+		t.Fatalf("Allow = %q, want %q", got, allowedMethods)
+	}
+	if fetchCalled {
+		t.Fatal("fetch was called for unsupported method")
+	}
+}
+
 func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -158,7 +210,13 @@ func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
 func testRequest(t *testing.T, target string) *http.Request {
 	t.Helper()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	return testRequestWithMethod(t, http.MethodGet, target)
+}
+
+func testRequestWithMethod(t *testing.T, method string, target string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), method, target, nil)
 	if err != nil {
 		t.Fatalf("NewRequestWithContext() returned error: %v", err)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -70,6 +70,7 @@ func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
 	}
+	assertCommonResponseHeaders(t, rr)
 	if fetchCalled {
 		t.Fatal("fetch was called for unauthorized request")
 	}
@@ -92,8 +93,9 @@ func TestCalendarFeedHandlerSuccess(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}
-	if got := rr.Header().Get("Content-Type"); got != "text/calendar" {
-		t.Fatalf("Content-Type = %q, want text/calendar", got)
+	assertCommonResponseHeaders(t, rr)
+	if got := rr.Header().Get("Content-Type"); got != calendarContentType {
+		t.Fatalf("Content-Type = %q, want %q", got, calendarContentType)
 	}
 	if got := rr.Body.String(); got != "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" {
 		t.Fatalf("body = %q, want calendar feed", got)
@@ -154,6 +156,7 @@ func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
 	if rr.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadGateway)
 	}
+	assertCommonResponseHeaders(t, rr)
 }
 
 func testRequest(t *testing.T, target string) *http.Request {
@@ -165,4 +168,15 @@ func testRequest(t *testing.T, target string) *http.Request {
 	}
 
 	return req
+}
+
+func assertCommonResponseHeaders(t *testing.T, rr *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if got := rr.Header().Get("Cache-Control"); got != cacheControlHeader {
+		t.Fatalf("Cache-Control = %q, want %q", got, cacheControlHeader)
+	}
+	if got := rr.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTokenMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+		want     bool
+	}{
+		{
+			name:     "matching token",
+			token:    "secret",
+			expected: "secret",
+			want:     true,
+		},
+		{
+			name:     "different token",
+			token:    "wrong",
+			expected: "secret",
+			want:     false,
+		},
+		{
+			name:     "empty token matches empty expected token",
+			token:    "",
+			expected: "",
+			want:     true,
+		},
+		{
+			name:     "empty token rejects non-empty expected token",
+			token:    "",
+			expected: "secret",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tokenMatches(tt.token, tt.expected)
+			if got != tt.want {
+				t.Fatalf("tokenMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
+	fetchCalled := false
+	handler := calendarFeedHandlerWithFetch(
+		"/calendars/private/feed",
+		CalendarConfig{Name: "private", Token: "secret"},
+		func(context.Context) ([]byte, error) {
+			fetchCalled = true
+			return []byte("should not be called"), nil
+		},
+	)
+
+	req := testRequest(t, "/calendars/private/feed?token=wrong")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if fetchCalled {
+		t.Fatal("fetch was called for unauthorized request")
+	}
+}
+
+func TestCalendarFeedHandlerSuccess(t *testing.T) {
+	handler := calendarFeedHandlerWithFetch(
+		"/calendars/private/feed",
+		CalendarConfig{Name: "private", Token: "secret"},
+		func(context.Context) ([]byte, error) {
+			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
+		},
+	)
+
+	req := testRequest(t, "/calendars/private/feed?token=secret")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "text/calendar" {
+		t.Fatalf("Content-Type = %q, want text/calendar", got)
+	}
+	if got := rr.Body.String(); got != "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" {
+		t.Fatalf("body = %q, want calendar feed", got)
+	}
+}
+
+func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
+	handler := calendarFeedHandlerWithFetch(
+		"/calendars/private/feed",
+		CalendarConfig{Name: "private", Token: "secret"},
+		func(context.Context) ([]byte, error) {
+			return nil, errors.New("upstream failed")
+		},
+	)
+
+	req := testRequest(t, "/calendars/private/feed?token=secret")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadGateway)
+	}
+}
+
+func testRequest(t *testing.T, target string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() returned error: %v", err)
+	}
+
+	return req
+}

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:              ":" + strconv.Itoa(listenPort),
-		Handler:           requestLoggingMiddleware(mux),
+		Handler:           requestLoggingMiddleware(recoveryMiddleware(mux)),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/main.go
+++ b/main.go
@@ -75,21 +75,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	// iterate through calendars in the config and setup a handler for each
-	// todo: consider refactor to route requests dynamically?
 	mux := http.NewServeMux()
-	for _, calendarConfig := range config.Calendars {
-
-		// configure HTTP endpoint
-		httpPath := "/calendars/" + calendarConfig.Name + "/feed"
-		slog.Debug("Configuring endpoint", "calendar", calendarConfig.Name, "http_path", httpPath)
-		mux.HandleFunc(httpPath, calendarFeedHandler(calendarConfig))
-
-	}
-
-	// add a readiness and liveness check endpoint (return blank 200 OK response)
-	mux.HandleFunc("/liveness", func(_ http.ResponseWriter, _ *http.Request) {})
-	mux.HandleFunc("/readiness", func(_ http.ResponseWriter, _ *http.Request) {})
+	registerPublicRoutes(mux, config)
+	registerInternalRoutes(mux)
 
 	server := &http.Server{
 		Addr:              ":" + strconv.Itoa(listenPort),

--- a/main.go
+++ b/main.go
@@ -1,16 +1,22 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 )
 
 var version = "development"
+
+const gracefulShutdownTimeout = 10 * time.Second
 
 func main() {
 
@@ -96,8 +102,36 @@ func main() {
 
 	// start the webserver
 	slog.Info("Starting web server", "port", listenPort)
-	if err := server.ListenAndServe(); err != nil {
-		slog.Error("Error starting web server", "error", err)
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.ListenAndServe()
+	}()
+
+	shutdownSignal := make(chan os.Signal, 1)
+	signal.Notify(shutdownSignal, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(shutdownSignal)
+
+	select {
+	case err := <-serverErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("Error running web server", "error", err)
+		}
+	case sig := <-shutdownSignal:
+		slog.Info("Stopping web server", "signal", sig.String())
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		defer cancel()
+
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			slog.Error("Error stopping web server", "error", err)
+			if closeErr := server.Close(); closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
+				slog.Error("Error closing web server", "error", closeErr)
+			}
+		}
+
+		if err := <-serverErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("Error running web server", "error", err)
+		}
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -75,37 +75,7 @@ func main() {
 		// configure HTTP endpoint
 		httpPath := "/calendars/" + calendarConfig.Name + "/feed"
 		slog.Debug("Configuring endpoint", "calendar", calendarConfig.Name, "http_path", httpPath)
-		http.HandleFunc(httpPath, func(w http.ResponseWriter, r *http.Request) {
-
-			slog.Debug("Received request for calendar", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
-
-			// validate token
-			token := r.URL.Query().Get("token")
-			if token != calendarConfig.Token {
-				slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			// fetch and filter upstream calendar
-			feed, err := calendarConfig.fetch(r.Context())
-			if err != nil {
-				slog.Error("Error fetching and filtering feed", "error", err)
-				http.Error(w, "Bad Gateway", http.StatusBadGateway)
-				return
-			}
-
-			// return calendar
-			w.Header().Set("Content-Type", "text/calendar")
-			_, err = w.Write(feed)
-			if err != nil {
-				slog.Error("Error writing response", "error", err)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-				return
-			}
-
-			slog.Info("Calendar request processed", "http_path", httpPath, "calendar", calendarConfig.Name, "client_ip", r.RemoteAddr)
-		})
+		http.HandleFunc(httpPath, calendarFeedHandler(httpPath, calendarConfig))
 
 	}
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 )
 
 var version = "development"
@@ -70,22 +71,32 @@ func main() {
 
 	// iterate through calendars in the config and setup a handler for each
 	// todo: consider refactor to route requests dynamically?
+	mux := http.NewServeMux()
 	for _, calendarConfig := range config.Calendars {
 
 		// configure HTTP endpoint
 		httpPath := "/calendars/" + calendarConfig.Name + "/feed"
 		slog.Debug("Configuring endpoint", "calendar", calendarConfig.Name, "http_path", httpPath)
-		http.HandleFunc(httpPath, calendarFeedHandler(httpPath, calendarConfig))
+		mux.HandleFunc(httpPath, calendarFeedHandler(httpPath, calendarConfig))
 
 	}
 
 	// add a readiness and liveness check endpoint (return blank 200 OK response)
-	http.HandleFunc("/liveness", func(_ http.ResponseWriter, _ *http.Request) {})
-	http.HandleFunc("/readiness", func(_ http.ResponseWriter, _ *http.Request) {})
+	mux.HandleFunc("/liveness", func(_ http.ResponseWriter, _ *http.Request) {})
+	mux.HandleFunc("/readiness", func(_ http.ResponseWriter, _ *http.Request) {})
+
+	server := &http.Server{
+		Addr:              ":" + strconv.Itoa(listenPort),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 
 	// start the webserver
 	slog.Info("Starting web server", "port", listenPort)
-	if err := http.ListenAndServe(":"+strconv.Itoa(listenPort), nil); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		slog.Error("Error starting web server", "error", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 		// configure HTTP endpoint
 		httpPath := "/calendars/" + calendarConfig.Name + "/feed"
 		slog.Debug("Configuring endpoint", "calendar", calendarConfig.Name, "http_path", httpPath)
-		mux.HandleFunc(httpPath, calendarFeedHandler(httpPath, calendarConfig))
+		mux.HandleFunc(httpPath, calendarFeedHandler(calendarConfig))
 
 	}
 
@@ -93,7 +93,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:              ":" + strconv.Itoa(listenPort),
-		Handler:           mux,
+		Handler:           requestLoggingMiddleware(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/middleware.go
+++ b/middleware.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"time"
 )
 
@@ -50,6 +52,25 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 			"client_ip", r.RemoteAddr,
 			"user_agent", r.UserAgent(),
 		)
+	})
+}
+
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				slog.Error(
+					"Recovered panic while processing HTTP request",
+					"panic", fmt.Sprint(recovered),
+					"path", r.URL.Path,
+					"client_ip", r.RemoteAddr,
+					"stack", string(debug.Stack()),
+				)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (r *statusRecorder) Write(body []byte) (int, error) {
+	if r.statusCode == 0 {
+		r.statusCode = http.StatusOK
+	}
+
+	return r.ResponseWriter.Write(body)
+}
+
+func requestLoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isHealthEndpoint(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		startedAt := time.Now()
+		recorder := &statusRecorder{ResponseWriter: w}
+
+		next.ServeHTTP(recorder, r)
+
+		statusCode := recorder.statusCode
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+
+		slog.Info(
+			"HTTP request processed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", statusCode,
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+			"client_ip", r.RemoteAddr,
+			"user_agent", r.UserAgent(),
+		)
+	})
+}
+
+func isHealthEndpoint(path string) bool {
+	return path == "/liveness" || path == "/readiness"
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestStatusRecorderCapturesExplicitStatus(t *testing.T) {
+	rr := httptest.NewRecorder()
+	recorder := &statusRecorder{ResponseWriter: rr}
+
+	recorder.WriteHeader(http.StatusTeapot)
+
+	if recorder.statusCode != http.StatusTeapot {
+		t.Fatalf("statusCode = %d, want %d", recorder.statusCode, http.StatusTeapot)
+	}
+	if rr.Code != http.StatusTeapot {
+		t.Fatalf("response code = %d, want %d", rr.Code, http.StatusTeapot)
+	}
+}
+
+func TestStatusRecorderCapturesImplicitOK(t *testing.T) {
+	rr := httptest.NewRecorder()
+	recorder := &statusRecorder{ResponseWriter: rr}
+
+	_, err := recorder.Write([]byte("ok"))
+	if err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+
+	if recorder.statusCode != http.StatusOK {
+		t.Fatalf("statusCode = %d, want %d", recorder.statusCode, http.StatusOK)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("response code = %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequestLoggingMiddlewareLogsPathWithoutQuery(t *testing.T) {
+	var logOutput bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/calendars/private/feed?token=secret", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() returned error: %v", err)
+	}
+	req.RemoteAddr = "192.0.2.1:12345"
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := logOutput.String()
+	if !strings.Contains(got, "path=/calendars/private/feed") {
+		t.Fatalf("log output = %q, want path without query", got)
+	}
+	if strings.Contains(got, "token=secret") {
+		t.Fatalf("log output contains query token: %q", got)
+	}
+	if !strings.Contains(got, "status=202") {
+		t.Fatalf("log output = %q, want status", got)
+	}
+}
+
+func TestRequestLoggingMiddlewareSkipsHealthEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "liveness",
+			path: "/liveness",
+		},
+		{
+			name: "readiness",
+			path: "/readiness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logOutput bytes.Buffer
+			originalLogger := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+			t.Cleanup(func() {
+				slog.SetDefault(originalLogger)
+			})
+
+			handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tt.path, nil)
+			if err != nil {
+				t.Fatalf("NewRequestWithContext() returned error: %v", err)
+			}
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got := logOutput.String(); got != "" {
+				t.Fatalf("log output = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestRequestLoggingMiddlewareLogsNonHealthEndpoint(t *testing.T) {
+	var logOutput bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/liveness/extra", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() returned error: %v", err)
+	}
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := logOutput.String(); !strings.Contains(got, "path=/liveness/extra") {
+		t.Fatalf("log output = %q, want non-health endpoint to be logged", got)
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -138,3 +138,58 @@ func TestRequestLoggingMiddlewareLogsNonHealthEndpoint(t *testing.T) {
 		t.Fatalf("log output = %q, want non-health endpoint to be logged", got)
 	}
 }
+
+func TestRecoveryMiddlewareReturnsInternalServerError(t *testing.T) {
+	var logOutput bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	handler := requestLoggingMiddleware(recoveryMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	})))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/calendars/private/feed", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() returned error: %v", err)
+	}
+	req.RemoteAddr = "192.0.2.1:12345"
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+
+	got := logOutput.String()
+	if !strings.Contains(got, "Recovered panic while processing HTTP request") {
+		t.Fatalf("log output = %q, want recovery log", got)
+	}
+	if !strings.Contains(got, "panic=boom") {
+		t.Fatalf("log output = %q, want panic value", got)
+	}
+	if !strings.Contains(got, "status=500") {
+		t.Fatalf("log output = %q, want request log status", got)
+	}
+}
+
+func TestRecoveryMiddlewarePassesThrough(t *testing.T) {
+	handler := recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/calendars/private/feed", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() returned error: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+}

--- a/routes.go
+++ b/routes.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+func registerPublicRoutes(mux *http.ServeMux, config Config) {
+	for _, calendarConfig := range config.Calendars {
+		httpPath := "/calendars/" + calendarConfig.Name + "/feed"
+		slog.Debug("Configuring endpoint", "calendar", calendarConfig.Name, "http_path", httpPath)
+		mux.HandleFunc(httpPath, calendarFeedHandler(calendarConfig))
+	}
+}
+
+func registerInternalRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/liveness", func(_ http.ResponseWriter, _ *http.Request) {})
+	mux.HandleFunc("/readiness", func(_ http.ResponseWriter, _ *http.Request) {})
+}

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterPublicRoutesRegistersCalendarFeeds(t *testing.T) {
+	mux := http.NewServeMux()
+	registerPublicRoutes(mux, Config{
+		Calendars: []CalendarConfig{
+			{
+				Name:  "private",
+				Token: "secret",
+			},
+		},
+	})
+
+	req := testRequest(t, "/calendars/private/feed")
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRegisterInternalRoutesRegistersHealthEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "liveness",
+			path: "/liveness",
+		},
+		{
+			name: "readiness",
+			path: "/readiness",
+		},
+	}
+
+	mux := http.NewServeMux()
+	registerInternalRoutes(mux)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := testRequest(t, tt.path)
+			rr := httptest.NewRecorder()
+
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+			}
+		})
+	}
+}
+
+func TestPublicAndInternalRoutesCanUseSeparateMuxes(t *testing.T) {
+	publicMux := http.NewServeMux()
+	registerPublicRoutes(publicMux, Config{
+		Calendars: []CalendarConfig{
+			{
+				Name:  "private",
+				Token: "secret",
+			},
+		},
+	})
+
+	internalMux := http.NewServeMux()
+	registerInternalRoutes(internalMux)
+
+	req := testRequest(t, "/liveness")
+	rr := httptest.NewRecorder()
+	publicMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("public mux status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+
+	req = testRequest(t, "/calendars/private/feed")
+	rr = httptest.NewRecorder()
+	internalMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("internal mux status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}

--- a/upstream.go
+++ b/upstream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -43,4 +44,21 @@ func fetchUpstreamCalendar(ctx context.Context, feedURL string) ([]byte, error) 
 	}
 
 	return feedData, nil
+}
+
+func redactURL(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "<invalid-url>"
+	}
+
+	redacted := parsedURL.Scheme + "://" + parsedURL.Host + "/..."
+	if parsedURL.RawQuery != "" {
+		redacted += "?REDACTED"
+	}
+	if parsedURL.Fragment != "" {
+		redacted += "#REDACTED"
+	}
+
+	return redacted
 }

--- a/upstream_test.go
+++ b/upstream_test.go
@@ -80,3 +80,56 @@ func TestFetchUpstreamCalendarUsesContext(t *testing.T) {
 		t.Fatalf("error = %v, want context.Canceled", err)
 	}
 }
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+	}{
+		{
+			name:   "redacts path token",
+			rawURL: "https://calendar.example.com/secret/path/feed.ics",
+			want:   "https://calendar.example.com/...",
+		},
+		{
+			name:   "preserves query presence",
+			rawURL: "https://calendar.example.com/secret/path/feed.ics?token=secret",
+			want:   "https://calendar.example.com/...?REDACTED",
+		},
+		{
+			name:   "preserves fragment presence",
+			rawURL: "https://calendar.example.com/secret/path/feed.ics#secret",
+			want:   "https://calendar.example.com/...#REDACTED",
+		},
+		{
+			name:   "preserves query and fragment presence",
+			rawURL: "https://calendar.example.com/secret/path/feed.ics?token=secret#secret",
+			want:   "https://calendar.example.com/...?REDACTED#REDACTED",
+		},
+		{
+			name:   "preserves host port",
+			rawURL: "http://localhost:8080/secret",
+			want:   "http://localhost:8080/...",
+		},
+		{
+			name:   "rejects relative url",
+			rawURL: "/secret/path",
+			want:   "<invalid-url>",
+		},
+		{
+			name:   "rejects malformed url",
+			rawURL: "://bad-url",
+			want:   "<invalid-url>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactURL(tt.rawURL)
+			if got != tt.want {
+				t.Fatalf("redactURL(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- add explicit `http.Server` configuration with timeouts
- add graceful shutdown for `SIGINT`/`SIGTERM` with timeouts
- harden response headers for calendar feeds
- add http request logging middleware and skip logging for `liveness` and `readiness` endpoints
- add panic recovery middleware to log and return `500`
- limit calendar feed methods to `GET` and `HEAD`
- split route registration into public and internal route helpers for future metrics support