### PR TITLE
improve string rule handling, validate regex at config load

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ These match conditions are available for a string value:
 - `contains` - property must contain this value
 - `prefix` - property must start with this value
 - `suffix` - property must end with this value
-- `regex` - property must match the given regular expression (an invalid regex will result in no matches)
+- `regex` - property must match the given regular expression. Invalid regular expressions are rejected when the configuration is loaded.
 
 #### Transformations
 
@@ -214,6 +214,8 @@ The following transformations are available for strings:
 
 - `replace` - the property is replace with this value
 - `remove` - if `true` the property is set to a blank string
+- `prefix` - this value is added before the existing property value
+- `suffix` - this value is added after the existing property value
 
 ### Secrets
 

--- a/config.go
+++ b/config.go
@@ -79,9 +79,36 @@ func (config *Config) LoadConfig(file string) bool {
 			slog.Warn("Calendar has no filters and will be proxy-only", "calendar", calendarConfig.Name)
 			continue
 		}
+
+		if !calendarConfig.validateFilters() {
+			return false
+		}
 	}
 
 	return true // config is parsed successfully
+}
+
+func (calendarConfig CalendarConfig) validateFilters() bool {
+	for filterIndex, filter := range calendarConfig.Filters {
+		matchRules := []struct {
+			name string
+			rule StringMatchRule
+		}{
+			{name: "summary", rule: filter.Match.Summary},
+			{name: "description", rule: filter.Match.Description},
+			{name: "location", rule: filter.Match.Location},
+			{name: "url", rule: filter.Match.URL},
+		}
+
+		for _, matchRule := range matchRules {
+			if err := matchRule.rule.validate(); err != nil {
+				slog.Error("Invalid string match rule", "calendar", calendarConfig.Name, "filter_index", filterIndex, "property", matchRule.name, "error", err)
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func readSecretFile(filePath string) (string, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -88,6 +88,21 @@ calendars:
 `,
 			want: false,
 		},
+		{
+			name: "invalid filter regex",
+			yaml: `
+calendars:
+  - name: public
+    public: true
+    feed_url: https://example.com/feed.ics
+    filters:
+      - description: invalid regex
+        match:
+          summary:
+            regex: "["
+`,
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/filter.go
+++ b/filter.go
@@ -72,32 +72,14 @@ func (filter Filter) transformEvent(event *ics.VEvent) {
 
 	// Summary transformations
 	eventSummaryValue := eventStringProperty(*event, ics.ComponentPropertySummary)
-	if filter.Transform.Summary.Remove {
-		event.SetSummary("")
-	}
-	if filter.Transform.Summary.Replace != "" {
-		event.SetSummary(filter.Transform.Summary.Replace)
-	}
-	if filter.Transform.Summary.Prefix != "" {
-		event.SetSummary(filter.Transform.Summary.Prefix + eventSummaryValue)
-	}
-	if filter.Transform.Summary.Suffix != "" {
-		event.SetSummary(eventSummaryValue + filter.Transform.Summary.Suffix)
+	if filter.Transform.Summary.hasActions() {
+		event.SetSummary(applyStringTransform(eventSummaryValue, filter.Transform.Summary))
 	}
 
 	// Description transformations
 	eventDescriptionValue := eventStringProperty(*event, ics.ComponentPropertyDescription)
-	if filter.Transform.Description.Remove {
-		event.SetDescription("")
-	}
-	if filter.Transform.Description.Replace != "" {
-		event.SetDescription(filter.Transform.Description.Replace)
-	}
-	if filter.Transform.Description.Prefix != "" {
-		event.SetDescription(filter.Transform.Description.Prefix + eventDescriptionValue)
-	}
-	if filter.Transform.Description.Suffix != "" {
-		event.SetDescription(eventDescriptionValue + filter.Transform.Description.Suffix)
+	if filter.Transform.Description.hasActions() {
+		event.SetDescription(applyStringTransform(eventDescriptionValue, filter.Transform.Description))
 	}
 
 	// Location transformations

--- a/filter.go
+++ b/filter.go
@@ -27,38 +27,16 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 		return false // never match if VEvent has no summary
 	}
 
-	// Check Summary filters against VEvent
-	if filter.Match.Summary.hasConditions() {
-		if !filter.Match.Summary.matchesString(eventSummary.Value) {
+	stringMatches := []eventStringMatch{
+		{property: ics.ComponentPropertySummary, name: "summary", rule: filter.Match.Summary},
+		{property: ics.ComponentPropertyDescription, name: "description", rule: filter.Match.Description},
+		{property: ics.ComponentPropertyLocation, name: "location", rule: filter.Match.Location},
+		{property: ics.ComponentPropertyUrl, name: "url", rule: filter.Match.URL},
+	}
+	for _, match := range stringMatches {
+		if !eventStringPropertyMatches(event, match.property, match.rule) {
+			slog.Debug("Event property does not match filter conditions", "property", match.name, "event_summary", eventSummary.Value, "filter", filter.Description)
 			return false
-		}
-	}
-
-	// Check Description filters against VEvent
-	if filter.Match.Description.hasConditions() {
-		eventDescriptionValue := eventStringProperty(event, ics.ComponentPropertyDescription)
-		if !filter.Match.Description.matchesString(eventDescriptionValue) {
-			slog.Debug("Event Description does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
-			return false // event doesn't match
-		}
-	}
-
-	// Check Location filters against VEvent
-	if filter.Match.Location.hasConditions() {
-		eventLocationValue := eventStringProperty(event, ics.ComponentPropertyLocation)
-		if !filter.Match.Location.matchesString(eventLocationValue) {
-			slog.Debug("Event Location does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
-			return false // event doesn't match
-
-		}
-	}
-
-	// Check URL filters against VEvent
-	if filter.Match.URL.hasConditions() {
-		eventURLValue := eventStringProperty(event, ics.ComponentPropertyUrl)
-		if !filter.Match.URL.matchesString(eventURLValue) {
-			slog.Debug("Event URL does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
-			return false // event doesn't match
 		}
 	}
 
@@ -109,6 +87,20 @@ type EventTransformRules struct {
 	Description StringTransformRule `yaml:"description"`
 	Location    StringTransformRule `yaml:"location"`
 	URL         StringTransformRule `yaml:"url"`
+}
+
+type eventStringMatch struct {
+	property ics.ComponentProperty
+	name     string
+	rule     StringMatchRule
+}
+
+func eventStringPropertyMatches(event ics.VEvent, property ics.ComponentProperty, rule StringMatchRule) bool {
+	if !rule.hasConditions() {
+		return true
+	}
+
+	return rule.matchesString(eventStringProperty(event, property))
 }
 
 func eventStringProperty(event ics.VEvent, property ics.ComponentProperty) string {

--- a/filter.go
+++ b/filter.go
@@ -83,17 +83,15 @@ func (filter Filter) transformEvent(event *ics.VEvent) {
 	}
 
 	// Location transformations
-	if filter.Transform.Location.Remove {
-		event.SetLocation("")
-	} else if filter.Transform.Location.Replace != "" {
-		event.SetLocation(filter.Transform.Location.Replace)
+	eventLocationValue := eventStringProperty(*event, ics.ComponentPropertyLocation)
+	if filter.Transform.Location.hasActions() {
+		event.SetLocation(applyStringTransform(eventLocationValue, filter.Transform.Location))
 	}
 
 	// URL transformations
-	if filter.Transform.URL.Remove {
-		event.SetURL("")
-	} else if filter.Transform.URL.Replace != "" {
-		event.SetURL(filter.Transform.URL.Replace)
+	eventURLValue := eventStringProperty(*event, ics.ComponentPropertyUrl)
+	if filter.Transform.URL.hasActions() {
+		event.SetURL(applyStringTransform(eventURLValue, filter.Transform.URL))
 	}
 }
 

--- a/filter.go
+++ b/filter.go
@@ -36,14 +36,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 
 	// Check Description filters against VEvent
 	if filter.Match.Description.hasConditions() {
-		eventDescription := event.GetProperty(ics.ComponentPropertyDescription)
-		var eventDescriptionValue string
-		if eventDescription == nil {
-			eventDescriptionValue = ""
-		} else {
-			eventDescriptionValue = eventDescription.Value
-		}
-
+		eventDescriptionValue := eventStringProperty(event, ics.ComponentPropertyDescription)
 		if !filter.Match.Description.matchesString(eventDescriptionValue) {
 			slog.Debug("Event Description does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
 			return false // event doesn't match
@@ -52,13 +45,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 
 	// Check Location filters against VEvent
 	if filter.Match.Location.hasConditions() {
-		eventLocation := event.GetProperty(ics.ComponentPropertyLocation)
-		var eventLocationValue string
-		if eventLocation == nil {
-			eventLocationValue = ""
-		} else {
-			eventLocationValue = eventLocation.Value
-		}
+		eventLocationValue := eventStringProperty(event, ics.ComponentPropertyLocation)
 		if !filter.Match.Location.matchesString(eventLocationValue) {
 			slog.Debug("Event Location does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
 			return false // event doesn't match
@@ -68,13 +55,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 
 	// Check URL filters against VEvent
 	if filter.Match.URL.hasConditions() {
-		eventURL := event.GetProperty(ics.ComponentPropertyUrl)
-		var eventURLValue string
-		if eventURL == nil {
-			eventURLValue = ""
-		} else {
-			eventURLValue = eventURL.Value
-		}
+		eventURLValue := eventStringProperty(event, ics.ComponentPropertyUrl)
 		if !filter.Match.URL.matchesString(eventURLValue) {
 			slog.Debug("Event URL does not match filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
 			return false // event doesn't match
@@ -90,13 +71,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 func (filter Filter) transformEvent(event *ics.VEvent) {
 
 	// Summary transformations
-	eventSummary := event.GetProperty(ics.ComponentPropertySummary)
-	var eventSummaryValue string
-	if eventSummary == nil {
-		eventSummaryValue = ""
-	} else {
-		eventSummaryValue = eventSummary.Value
-	}
+	eventSummaryValue := eventStringProperty(*event, ics.ComponentPropertySummary)
 	if filter.Transform.Summary.Remove {
 		event.SetSummary("")
 	}
@@ -111,13 +86,7 @@ func (filter Filter) transformEvent(event *ics.VEvent) {
 	}
 
 	// Description transformations
-	eventDescription := event.GetProperty(ics.ComponentPropertyDescription)
-	var eventDescriptionValue string
-	if eventDescription == nil {
-		eventDescriptionValue = ""
-	} else {
-		eventDescriptionValue = eventDescription.Value
-	}
+	eventDescriptionValue := eventStringProperty(*event, ics.ComponentPropertyDescription)
 	if filter.Transform.Description.Remove {
 		event.SetDescription("")
 	}
@@ -160,4 +129,13 @@ type EventTransformRules struct {
 	Description StringTransformRule `yaml:"description"`
 	Location    StringTransformRule `yaml:"location"`
 	URL         StringTransformRule `yaml:"url"`
+}
+
+func eventStringProperty(event ics.VEvent, property ics.ComponentProperty) string {
+	eventProperty := event.GetProperty(property)
+	if eventProperty == nil {
+		return ""
+	}
+
+	return eventProperty.Value
 }

--- a/filter.go
+++ b/filter.go
@@ -47,29 +47,14 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 
 // Applies filter transformations to a VEvent pointer
 func (filter Filter) transformEvent(event *ics.VEvent) {
-
-	// Summary transformations
-	eventSummaryValue := eventStringProperty(*event, ics.ComponentPropertySummary)
-	if filter.Transform.Summary.hasActions() {
-		event.SetSummary(applyStringTransform(eventSummaryValue, filter.Transform.Summary))
+	stringTransforms := []eventStringTransform{
+		{property: ics.ComponentPropertySummary, rule: filter.Transform.Summary, set: func(value string) { event.SetSummary(value) }},
+		{property: ics.ComponentPropertyDescription, rule: filter.Transform.Description, set: func(value string) { event.SetDescription(value) }},
+		{property: ics.ComponentPropertyLocation, rule: filter.Transform.Location, set: func(value string) { event.SetLocation(value) }},
+		{property: ics.ComponentPropertyUrl, rule: filter.Transform.URL, set: func(value string) { event.SetURL(value) }},
 	}
-
-	// Description transformations
-	eventDescriptionValue := eventStringProperty(*event, ics.ComponentPropertyDescription)
-	if filter.Transform.Description.hasActions() {
-		event.SetDescription(applyStringTransform(eventDescriptionValue, filter.Transform.Description))
-	}
-
-	// Location transformations
-	eventLocationValue := eventStringProperty(*event, ics.ComponentPropertyLocation)
-	if filter.Transform.Location.hasActions() {
-		event.SetLocation(applyStringTransform(eventLocationValue, filter.Transform.Location))
-	}
-
-	// URL transformations
-	eventURLValue := eventStringProperty(*event, ics.ComponentPropertyUrl)
-	if filter.Transform.URL.hasActions() {
-		event.SetURL(applyStringTransform(eventURLValue, filter.Transform.URL))
+	for _, transform := range stringTransforms {
+		applyEventStringTransform(*event, transform)
 	}
 }
 
@@ -95,12 +80,27 @@ type eventStringMatch struct {
 	rule     StringMatchRule
 }
 
+type eventStringTransform struct {
+	property ics.ComponentProperty
+	rule     StringTransformRule
+	set      func(string)
+}
+
 func eventStringPropertyMatches(event ics.VEvent, property ics.ComponentProperty, rule StringMatchRule) bool {
 	if !rule.hasConditions() {
 		return true
 	}
 
 	return rule.matchesString(eventStringProperty(event, property))
+}
+
+func applyEventStringTransform(event ics.VEvent, transform eventStringTransform) {
+	if !transform.rule.hasActions() {
+		return
+	}
+
+	value := eventStringProperty(event, transform.property)
+	transform.set(applyStringTransform(value, transform.rule))
 }
 
 func eventStringProperty(event ics.VEvent, property ics.ComponentProperty) string {

--- a/filter_test.go
+++ b/filter_test.go
@@ -149,6 +149,54 @@ func TestEventStringProperty(t *testing.T) {
 	}
 }
 
+func TestEventStringPropertyMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *ics.VEvent
+		property ics.ComponentProperty
+		rule     StringMatchRule
+		want     bool
+	}{
+		{
+			name:     "empty rule matches",
+			event:    testEvent("team calendar event"),
+			property: ics.ComponentPropertySummary,
+			rule:     StringMatchRule{},
+			want:     true,
+		},
+		{
+			name:     "property value matches",
+			event:    testEvent("team calendar event"),
+			property: ics.ComponentPropertySummary,
+			rule:     StringMatchRule{Contains: "calendar"},
+			want:     true,
+		},
+		{
+			name:     "property value mismatch",
+			event:    testEvent("team calendar event"),
+			property: ics.ComponentPropertySummary,
+			rule:     StringMatchRule{Contains: "holiday"},
+			want:     false,
+		},
+		{
+			name:     "missing property matches empty rule",
+			event:    testEvent("team calendar event"),
+			property: ics.ComponentPropertyDescription,
+			rule:     StringMatchRule{Null: true},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eventStringPropertyMatches(*tt.event, tt.property, tt.rule)
+			if got != tt.want {
+				t.Fatalf("eventStringPropertyMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFilterTransformEvent(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/filter_test.go
+++ b/filter_test.go
@@ -186,16 +186,18 @@ func TestFilterTransformEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "prefix and suffix summary and description",
+			name: "prefix and suffix fields",
 			transform: EventTransformRules{
 				Summary:     StringTransformRule{Prefix: "[", Suffix: "]"},
 				Description: StringTransformRule{Prefix: "(", Suffix: ")"},
+				Location:    StringTransformRule{Prefix: "Location: "},
+				URL:         StringTransformRule{Suffix: "?tracked=true"},
 			},
 			want: map[ics.ComponentProperty]string{
 				ics.ComponentPropertySummary:     "[original summary]",
 				ics.ComponentPropertyDescription: "(original description)",
-				ics.ComponentPropertyLocation:    "original location",
-				ics.ComponentPropertyUrl:         "https://example.com/original",
+				ics.ComponentPropertyLocation:    "Location: original location",
+				ics.ComponentPropertyUrl:         "https://example.com/original?tracked=true",
 			},
 		},
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -197,6 +197,59 @@ func TestEventStringPropertyMatches(t *testing.T) {
 	}
 }
 
+func TestApplyEventStringTransform(t *testing.T) {
+	t.Run("empty transform does not call setter", func(t *testing.T) {
+		called := false
+		event := testEvent("team calendar event")
+
+		applyEventStringTransform(*event, eventStringTransform{
+			property: ics.ComponentPropertySummary,
+			rule:     StringTransformRule{},
+			set: func(_ string) {
+				called = true
+			},
+		})
+
+		if called {
+			t.Fatal("setter called for empty transform")
+		}
+	})
+
+	t.Run("transform uses existing property value", func(t *testing.T) {
+		var got string
+		event := testEvent("team calendar event")
+
+		applyEventStringTransform(*event, eventStringTransform{
+			property: ics.ComponentPropertySummary,
+			rule:     StringTransformRule{Prefix: "[", Suffix: "]"},
+			set: func(value string) {
+				got = value
+			},
+		})
+
+		if got != "[team calendar event]" {
+			t.Fatalf("setter value = %q, want %q", got, "[team calendar event]")
+		}
+	})
+
+	t.Run("missing property transforms empty value", func(t *testing.T) {
+		var got string
+		event := testEvent("team calendar event")
+
+		applyEventStringTransform(*event, eventStringTransform{
+			property: ics.ComponentPropertyDescription,
+			rule:     StringTransformRule{Prefix: "missing: "},
+			set: func(value string) {
+				got = value
+			},
+		})
+
+		if got != "missing: " {
+			t.Fatalf("setter value = %q, want %q", got, "missing: ")
+		}
+	})
+}
+
 func TestFilterTransformEvent(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/filter_test.go
+++ b/filter_test.go
@@ -192,8 +192,8 @@ func TestFilterTransformEvent(t *testing.T) {
 				Description: StringTransformRule{Prefix: "(", Suffix: ")"},
 			},
 			want: map[ics.ComponentProperty]string{
-				ics.ComponentPropertySummary:     "original summary]",
-				ics.ComponentPropertyDescription: "original description)",
+				ics.ComponentPropertySummary:     "[original summary]",
+				ics.ComponentPropertyDescription: "(original description)",
 				ics.ComponentPropertyLocation:    "original location",
 				ics.ComponentPropertyUrl:         "https://example.com/original",
 			},

--- a/filter_test.go
+++ b/filter_test.go
@@ -138,6 +138,17 @@ func TestFilterMatchesEvent(t *testing.T) {
 	}
 }
 
+func TestEventStringProperty(t *testing.T) {
+	event := testEvent("team calendar event")
+
+	if got := eventStringProperty(*event, ics.ComponentPropertySummary); got != "team calendar event" {
+		t.Fatalf("summary = %q, want team calendar event", got)
+	}
+	if got := eventStringProperty(*event, ics.ComponentPropertyDescription); got != "" {
+		t.Fatalf("missing description = %q, want empty string", got)
+	}
+}
+
 func TestFilterTransformEvent(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/string_rules.go
+++ b/string_rules.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -22,6 +23,18 @@ func (smr StringMatchRule) hasConditions() bool {
 		smr.Prefix != "" ||
 		smr.Suffix != "" ||
 		smr.RegexMatch != ""
+}
+
+func (smr StringMatchRule) validate() error {
+	if smr.RegexMatch == "" {
+		return nil
+	}
+
+	if _, err := regexp.Compile(smr.RegexMatch); err != nil {
+		return fmt.Errorf("invalid regex %q: %w", smr.RegexMatch, err)
+	}
+
+	return nil
 }
 
 // Returns true if a given string (data) matches ALL StringMatchRule conditions

--- a/string_rules.go
+++ b/string_rules.go
@@ -70,3 +70,27 @@ type StringTransformRule struct {
 	Prefix  string `yaml:"prefix"`
 	Suffix  string `yaml:"suffix"`
 }
+
+func (str StringTransformRule) hasActions() bool {
+	return str.Replace != "" ||
+		str.Remove ||
+		str.Prefix != "" ||
+		str.Suffix != ""
+}
+
+func applyStringTransform(value string, rule StringTransformRule) string {
+	if rule.Remove {
+		return ""
+	}
+	if rule.Replace != "" {
+		return rule.Replace
+	}
+	if rule.Prefix != "" {
+		value = rule.Prefix + value
+	}
+	if rule.Suffix != "" {
+		value += rule.Suffix
+	}
+
+	return value
+}

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -50,6 +50,39 @@ func TestStringMatchRuleHasConditions(t *testing.T) {
 	}
 }
 
+func TestStringMatchRuleValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    StringMatchRule
+		wantErr bool
+	}{
+		{
+			name:    "empty rule is valid",
+			rule:    StringMatchRule{},
+			wantErr: false,
+		},
+		{
+			name:    "valid regex is valid",
+			rule:    StringMatchRule{RegexMatch: `cal.*event`},
+			wantErr: false,
+		},
+		{
+			name:    "invalid regex is invalid",
+			rule:    StringMatchRule{RegexMatch: `[`},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rule.validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestStringMatchRuleMatchesString(t *testing.T) {
 	tests := []struct {
 		name string

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -174,3 +174,101 @@ func TestStringMatchRuleMatchesString(t *testing.T) {
 		})
 	}
 }
+
+func TestStringTransformRuleHasActions(t *testing.T) {
+	tests := []struct {
+		name string
+		rule StringTransformRule
+		want bool
+	}{
+		{
+			name: "empty rule",
+			rule: StringTransformRule{},
+			want: false,
+		},
+		{
+			name: "replace action",
+			rule: StringTransformRule{Replace: "new"},
+			want: true,
+		},
+		{
+			name: "remove action",
+			rule: StringTransformRule{Remove: true},
+			want: true,
+		},
+		{
+			name: "prefix action",
+			rule: StringTransformRule{Prefix: "new "},
+			want: true,
+		},
+		{
+			name: "suffix action",
+			rule: StringTransformRule{Suffix: " new"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.rule.hasActions()
+			if got != tt.want {
+				t.Fatalf("hasActions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyStringTransform(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		rule  StringTransformRule
+		want  string
+	}{
+		{
+			name:  "empty rule keeps value",
+			value: "calendar event",
+			rule:  StringTransformRule{},
+			want:  "calendar event",
+		},
+		{
+			name:  "remove wins",
+			value: "calendar event",
+			rule:  StringTransformRule{Remove: true, Replace: "replacement", Prefix: "[", Suffix: "]"},
+			want:  "",
+		},
+		{
+			name:  "replace wins over prefix and suffix",
+			value: "calendar event",
+			rule:  StringTransformRule{Replace: "replacement", Prefix: "[", Suffix: "]"},
+			want:  "replacement",
+		},
+		{
+			name:  "prefix and suffix apply together",
+			value: "calendar event",
+			rule:  StringTransformRule{Prefix: "[", Suffix: "]"},
+			want:  "[calendar event]",
+		},
+		{
+			name:  "prefix applies to empty value",
+			value: "",
+			rule:  StringTransformRule{Prefix: "prefix"},
+			want:  "prefix",
+		},
+		{
+			name:  "suffix applies to empty value",
+			value: "",
+			rule:  StringTransformRule{Suffix: "suffix"},
+			want:  "suffix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyStringTransform(tt.value, tt.rule)
+			if got != tt.want {
+				t.Fatalf("applyStringTransform() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- add shared helpers for reading string properties and evaluating string rules on events
- refactor string matching and string transforms to use table-driven helpers
- make location and url support the same string transforms as summary/description
- update transform behavior so prefix and suffix apply together when both are set, unless remove or replace is configured
- add startup validation for invalid regex match rules, causing config load to fail at startup
- add tests for string helpers, transform precedence, event property helpers, and regex validation