### PR TITLE
refactor config loading into compiled runtime configuration

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -40,6 +40,9 @@ type Calendar struct {
 	Filters     []Filter
 }
 
+// RuntimeConfig converts validated YAML config into runtime state used by the
+// HTTP server. This is where raw match rules are compiled and regex syntax
+// errors become startup validation failures.
 func (config Config) RuntimeConfig() (RuntimeConfig, error) {
 	calendars := make([]Calendar, 0, len(config.Calendars))
 	for _, calendarConfig := range config.Calendars {

--- a/calendar.go
+++ b/calendar.go
@@ -40,10 +40,10 @@ type Calendar struct {
 	Filters     []Filter
 }
 
-// RuntimeConfig converts validated YAML config into runtime state used by the
-// HTTP server. This is where raw match rules are compiled and regex syntax
-// errors become startup validation failures.
-func (config Config) RuntimeConfig() (RuntimeConfig, error) {
+// Compile converts validated YAML config into runtime state used by the HTTP
+// server. This is where raw match rules are compiled and regex syntax errors
+// become startup validation failures.
+func (config Config) Compile() (RuntimeConfig, error) {
 	calendars := make([]Calendar, 0, len(config.Calendars))
 	for _, calendarConfig := range config.Calendars {
 		filters := make([]Filter, 0, len(calendarConfig.Filters))

--- a/calendar.go
+++ b/calendar.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -34,23 +35,32 @@ type Calendar struct {
 	Public      bool
 	Token       string
 	FeedURL     string
-	Filters     []Filter
+	Filters     []CompiledFilter
 }
 
-func (config Config) RuntimeConfig() RuntimeConfig {
+func (config Config) RuntimeConfig() (RuntimeConfig, error) {
 	calendars := make([]Calendar, 0, len(config.Calendars))
 	for _, calendarConfig := range config.Calendars {
+		filters := make([]CompiledFilter, 0, len(calendarConfig.Filters))
+		for filterIndex, filter := range calendarConfig.Filters {
+			compiledFilter, err := filter.compile()
+			if err != nil {
+				return RuntimeConfig{}, fmt.Errorf("calendar %q filter %d: %w", calendarConfig.Name, filterIndex, err)
+			}
+			filters = append(filters, compiledFilter)
+		}
+
 		calendars = append(calendars, Calendar{
 			Name:        calendarConfig.Name,
 			PublishName: calendarConfig.PublishName,
 			Public:      calendarConfig.Public,
 			Token:       calendarConfig.Token,
 			FeedURL:     calendarConfig.FeedURL,
-			Filters:     calendarConfig.Filters,
+			Filters:     filters,
 		})
 	}
 
-	return RuntimeConfig{Calendars: calendars}
+	return RuntimeConfig{Calendars: calendars}, nil
 }
 
 // Downloads iCal feed from the URL and applies filtering rules

--- a/calendar.go
+++ b/calendar.go
@@ -24,12 +24,41 @@ type CalendarConfig struct {
 	Filters     []Filter `yaml:"filters"`
 }
 
+type RuntimeConfig struct {
+	Calendars []Calendar
+}
+
+type Calendar struct {
+	Name        string
+	PublishName string
+	Public      bool
+	Token       string
+	FeedURL     string
+	Filters     []Filter
+}
+
+func (config Config) RuntimeConfig() RuntimeConfig {
+	calendars := make([]Calendar, 0, len(config.Calendars))
+	for _, calendarConfig := range config.Calendars {
+		calendars = append(calendars, Calendar{
+			Name:        calendarConfig.Name,
+			PublishName: calendarConfig.PublishName,
+			Public:      calendarConfig.Public,
+			Token:       calendarConfig.Token,
+			FeedURL:     calendarConfig.FeedURL,
+			Filters:     calendarConfig.Filters,
+		})
+	}
+
+	return RuntimeConfig{Calendars: calendars}
+}
+
 // Downloads iCal feed from the URL and applies filtering rules
-func (calendarConfig CalendarConfig) fetch(ctx context.Context) ([]byte, error) {
+func (calendar Calendar) fetch(ctx context.Context) ([]byte, error) {
 
 	// get the iCal feed
-	slog.Debug("Fetching iCal feed", "url", redactURL(calendarConfig.FeedURL))
-	feedData, err := fetchUpstreamCalendar(ctx, calendarConfig.FeedURL)
+	slog.Debug("Fetching iCal feed", "url", redactURL(calendar.FeedURL))
+	feedData, err := fetchUpstreamCalendar(ctx, calendar.FeedURL)
 	if err != nil {
 		return nil, err
 	}
@@ -40,21 +69,21 @@ func (calendarConfig CalendarConfig) fetch(ctx context.Context) ([]byte, error) 
 		return nil, err
 	}
 
-	if calendarConfig.PublishName != "" {
-		cal.SetName(calendarConfig.PublishName)
+	if calendar.PublishName != "" {
+		cal.SetName(calendar.PublishName)
 	}
 
 	// process filters
-	if len(calendarConfig.Filters) > 0 {
-		slog.Debug("Processing filters", "calendar", calendarConfig.Name)
+	if len(calendar.Filters) > 0 {
+		slog.Debug("Processing filters", "calendar", calendar.Name)
 		for _, event := range cal.Events() {
-			if !calendarConfig.ProcessEvent(event) {
+			if !calendar.ProcessEvent(event) {
 				cal.RemoveEvent(event.Id())
 			}
 		}
-		slog.Debug("Filter processing completed", "calendar", calendarConfig.Name)
+		slog.Debug("Filter processing completed", "calendar", calendar.Name)
 	} else {
-		slog.Debug("No filters to evaluate", "calendar", calendarConfig.Name)
+		slog.Debug("No filters to evaluate", "calendar", calendar.Name)
 	}
 
 	// serialize output
@@ -71,7 +100,7 @@ func (calendarConfig CalendarConfig) fetch(ctx context.Context) ([]byte, error) 
 // Evaluate the filters for a calendar against a given VEvent and
 // perform any transformations directly to the VEvent (pointer)
 // This function returns false if an event should be deleted
-func (calendarConfig CalendarConfig) ProcessEvent(event *ics.VEvent) bool {
+func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 
 	// Get the Summary (the "title" of the event)
 	// In case we cannot parse the event summary it should get dropped
@@ -81,7 +110,7 @@ func (calendarConfig CalendarConfig) ProcessEvent(event *ics.VEvent) bool {
 	}
 
 	// Iterate through the Filter rules
-	for id, filter := range calendarConfig.Filters {
+	for id, filter := range calendar.Filters {
 
 		// Does the filter match the event?
 		if filter.matchesEvent(*event) {

--- a/calendar.go
+++ b/calendar.go
@@ -10,10 +10,9 @@ import (
 	ics "github.com/arran4/golang-ical"
 )
 
-// All structs defined in this file are used to unmarshall yaml configuration and
-// provide helper functions that are used to fetch and filter events
-
-// CalendarConfig definition
+// CalendarConfig is the YAML-backed calendar configuration. It is converted
+// into Calendar before request handling so runtime code uses compiled filters
+// and resolved secret values.
 type CalendarConfig struct {
 	Name        string   `yaml:"name"`
 	PublishName string   `yaml:"publish_name"`
@@ -29,6 +28,9 @@ type RuntimeConfig struct {
 	Calendars []Calendar
 }
 
+// Calendar is the runtime calendar representation used by handlers. It should
+// contain values that are ready to execute, not file paths or raw rule strings
+// that still need to be resolved.
 type Calendar struct {
 	Name        string
 	PublishName string

--- a/calendar.go
+++ b/calendar.go
@@ -14,14 +14,14 @@ import (
 // into Calendar before request handling so runtime code uses compiled filters
 // and resolved secret values.
 type CalendarConfig struct {
-	Name        string   `yaml:"name"`
-	PublishName string   `yaml:"publish_name"`
-	Public      bool     `yaml:"public"`
-	Token       string   `yaml:"token"`
-	TokenFile   string   `yaml:"token_file"`
-	FeedURL     string   `yaml:"feed_url"`
-	FeedURLFile string   `yaml:"feed_url_file"`
-	Filters     []Filter `yaml:"filters"`
+	Name        string         `yaml:"name"`
+	PublishName string         `yaml:"publish_name"`
+	Public      bool           `yaml:"public"`
+	Token       string         `yaml:"token"`
+	TokenFile   string         `yaml:"token_file"`
+	FeedURL     string         `yaml:"feed_url"`
+	FeedURLFile string         `yaml:"feed_url_file"`
+	Filters     []FilterConfig `yaml:"filters"`
 }
 
 type RuntimeConfig struct {
@@ -37,13 +37,13 @@ type Calendar struct {
 	Public      bool
 	Token       string
 	FeedURL     string
-	Filters     []CompiledFilter
+	Filters     []Filter
 }
 
 func (config Config) RuntimeConfig() (RuntimeConfig, error) {
 	calendars := make([]Calendar, 0, len(config.Calendars))
 	for _, calendarConfig := range config.Calendars {
-		filters := make([]CompiledFilter, 0, len(calendarConfig.Filters))
+		filters := make([]Filter, 0, len(calendarConfig.Filters))
 		for filterIndex, filter := range calendarConfig.Filters {
 			compiledFilter, err := filter.compile()
 			if err != nil {

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -10,14 +10,14 @@ import (
 	ics "github.com/arran4/golang-ical"
 )
 
-func TestCalendarConfigFetch(t *testing.T) {
+func TestCalendarFetch(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/calendar")
 		_, _ = w.Write([]byte(testCalendarFeed))
 	}))
 	defer server.Close()
 
-	config := CalendarConfig{
+	config := Calendar{
 		Name:        "test",
 		PublishName: "Filtered Calendar",
 		FeedURL:     server.URL,
@@ -80,17 +80,17 @@ func TestCalendarConfigFetch(t *testing.T) {
 	}
 }
 
-func TestCalendarConfigProcessEvent(t *testing.T) {
+func TestCalendarProcessEvent(t *testing.T) {
 	tests := []struct {
 		name        string
-		config      CalendarConfig
+		config      Calendar
 		event       *ics.VEvent
 		wantKeep    bool
 		wantSummary string
 	}{
 		{
 			name: "keeps event by default when no filters match",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{
 					{
 						Description: "Remove canceled events",
@@ -107,7 +107,7 @@ func TestCalendarConfigProcessEvent(t *testing.T) {
 		},
 		{
 			name: "removes event when remove filter matches",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{
 					{
 						Description: "Remove canceled events",
@@ -124,7 +124,7 @@ func TestCalendarConfigProcessEvent(t *testing.T) {
 		},
 		{
 			name: "transforms matching event and keeps it",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{
 					{
 						Description: "Rename on-call events",
@@ -143,7 +143,7 @@ func TestCalendarConfigProcessEvent(t *testing.T) {
 		},
 		{
 			name: "stop prevents later matching filters",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{
 					{
 						Description: "Rename and stop",
@@ -164,7 +164,7 @@ func TestCalendarConfigProcessEvent(t *testing.T) {
 		},
 		{
 			name: "transform continues to later filters when stop is false",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{
 					{
 						Description: "Rename without stop",
@@ -187,7 +187,7 @@ func TestCalendarConfigProcessEvent(t *testing.T) {
 		},
 		{
 			name: "filter without match rules matches all events",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{
 					{
 						Description: "Remove everything",
@@ -201,7 +201,7 @@ func TestCalendarConfigProcessEvent(t *testing.T) {
 		},
 		{
 			name: "drops event without summary",
-			config: CalendarConfig{
+			config: Calendar{
 				Filters: []Filter{},
 			},
 			event:       ics.NewEvent("missing-summary"),

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -26,13 +26,13 @@ func TestCalendarFetch(t *testing.T) {
 				Description: "Remove canceled events",
 				RemoveEvent: true,
 				Match: EventMatchRules{
-					Summary: StringMatchRule{Prefix: "Canceled: "},
+					Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 				},
 			},
 			{
 				Description: "Rename on-call event",
 				Match: EventMatchRules{
-					Summary: StringMatchRule{Contains: "schedule: oncall"},
+					Summary: StringMatchRuleConfig{Contains: "schedule: oncall"},
 				},
 				Transform: EventTransformRules{
 					Summary: StringTransformRule{Replace: "On-Call"},
@@ -96,7 +96,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 						Description: "Remove canceled events",
 						RemoveEvent: true,
 						Match: EventMatchRules{
-							Summary: StringMatchRule{Prefix: "Canceled: "},
+							Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 						},
 					},
 				}),
@@ -113,7 +113,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 						Description: "Remove canceled events",
 						RemoveEvent: true,
 						Match: EventMatchRules{
-							Summary: StringMatchRule{Prefix: "Canceled: "},
+							Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 						},
 					},
 				}),
@@ -129,7 +129,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 					{
 						Description: "Rename on-call events",
 						Match: EventMatchRules{
-							Summary: StringMatchRule{Contains: "schedule: oncall"},
+							Summary: StringMatchRuleConfig{Contains: "schedule: oncall"},
 						},
 						Transform: EventTransformRules{
 							Summary: StringTransformRule{Replace: "On-Call"},
@@ -176,7 +176,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 						Description: "Remove transformed event",
 						RemoveEvent: true,
 						Match: EventMatchRules{
-							Summary: StringMatchRule{Contains: "Remove"},
+							Summary: StringMatchRuleConfig{Contains: "Remove"},
 						},
 					},
 				}),

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -21,7 +21,7 @@ func TestCalendarFetch(t *testing.T) {
 		Name:        "test",
 		PublishName: "Filtered Calendar",
 		FeedURL:     server.URL,
-		Filters: mustCompileFilters(t, []Filter{
+		Filters: mustCompileFilters(t, []FilterConfig{
 			{
 				Description: "Remove canceled events",
 				RemoveEvent: true,
@@ -91,7 +91,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "keeps event by default when no filters match",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{
+				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Remove canceled events",
 						RemoveEvent: true,
@@ -108,7 +108,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "removes event when remove filter matches",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{
+				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Remove canceled events",
 						RemoveEvent: true,
@@ -125,7 +125,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "transforms matching event and keeps it",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{
+				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Rename on-call events",
 						Match: EventMatchRules{
@@ -144,7 +144,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "stop prevents later matching filters",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{
+				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Rename and stop",
 						Stop:        true,
@@ -165,7 +165,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "transform continues to later filters when stop is false",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{
+				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Rename without stop",
 						Transform: EventTransformRules{
@@ -188,7 +188,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "filter without match rules matches all events",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{
+				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Remove everything",
 						RemoveEvent: true,
@@ -202,7 +202,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "drops event without summary",
 			config: Calendar{
-				Filters: mustCompileFilters(t, []Filter{}),
+				Filters: mustCompileFilters(t, []FilterConfig{}),
 			},
 			event:       ics.NewEvent("missing-summary"),
 			wantKeep:    false,

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -21,7 +21,7 @@ func TestCalendarFetch(t *testing.T) {
 		Name:        "test",
 		PublishName: "Filtered Calendar",
 		FeedURL:     server.URL,
-		Filters: []Filter{
+		Filters: mustCompileFilters(t, []Filter{
 			{
 				Description: "Remove canceled events",
 				RemoveEvent: true,
@@ -38,7 +38,7 @@ func TestCalendarFetch(t *testing.T) {
 					Summary: StringTransformRule{Replace: "On-Call"},
 				},
 			},
-		},
+		}),
 	}
 
 	feed, err := config.fetch(context.Background())
@@ -91,7 +91,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "keeps event by default when no filters match",
 			config: Calendar{
-				Filters: []Filter{
+				Filters: mustCompileFilters(t, []Filter{
 					{
 						Description: "Remove canceled events",
 						RemoveEvent: true,
@@ -99,7 +99,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 							Summary: StringMatchRule{Prefix: "Canceled: "},
 						},
 					},
-				},
+				}),
 			},
 			event:       testEvent("Team sync"),
 			wantKeep:    true,
@@ -108,7 +108,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "removes event when remove filter matches",
 			config: Calendar{
-				Filters: []Filter{
+				Filters: mustCompileFilters(t, []Filter{
 					{
 						Description: "Remove canceled events",
 						RemoveEvent: true,
@@ -116,7 +116,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 							Summary: StringMatchRule{Prefix: "Canceled: "},
 						},
 					},
-				},
+				}),
 			},
 			event:       testEvent("Canceled: Team sync"),
 			wantKeep:    false,
@@ -125,7 +125,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "transforms matching event and keeps it",
 			config: Calendar{
-				Filters: []Filter{
+				Filters: mustCompileFilters(t, []Filter{
 					{
 						Description: "Rename on-call events",
 						Match: EventMatchRules{
@@ -135,7 +135,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 							Summary: StringTransformRule{Replace: "On-Call"},
 						},
 					},
-				},
+				}),
 			},
 			event:       testEvent("ops schedule: oncall"),
 			wantKeep:    true,
@@ -144,7 +144,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "stop prevents later matching filters",
 			config: Calendar{
-				Filters: []Filter{
+				Filters: mustCompileFilters(t, []Filter{
 					{
 						Description: "Rename and stop",
 						Stop:        true,
@@ -156,7 +156,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 						Description: "Remove everything else",
 						RemoveEvent: true,
 					},
-				},
+				}),
 			},
 			event:       testEvent("Original"),
 			wantKeep:    true,
@@ -165,7 +165,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "transform continues to later filters when stop is false",
 			config: Calendar{
-				Filters: []Filter{
+				Filters: mustCompileFilters(t, []Filter{
 					{
 						Description: "Rename without stop",
 						Transform: EventTransformRules{
@@ -179,7 +179,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 							Summary: StringMatchRule{Contains: "Remove"},
 						},
 					},
-				},
+				}),
 			},
 			event:       testEvent("Original"),
 			wantKeep:    false,
@@ -188,12 +188,12 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "filter without match rules matches all events",
 			config: Calendar{
-				Filters: []Filter{
+				Filters: mustCompileFilters(t, []Filter{
 					{
 						Description: "Remove everything",
 						RemoveEvent: true,
 					},
-				},
+				}),
 			},
 			event:       testEvent("Original"),
 			wantKeep:    false,
@@ -202,7 +202,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 		{
 			name: "drops event without summary",
 			config: Calendar{
-				Filters: []Filter{},
+				Filters: mustCompileFilters(t, []Filter{}),
 			},
 			event:       ics.NewEvent("missing-summary"),
 			wantKeep:    false,

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -25,13 +25,13 @@ func TestCalendarFetch(t *testing.T) {
 			{
 				Description: "Remove canceled events",
 				RemoveEvent: true,
-				Match: EventMatchRules{
+				Match: EventMatchRulesConfig{
 					Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 				},
 			},
 			{
 				Description: "Rename on-call event",
-				Match: EventMatchRules{
+				Match: EventMatchRulesConfig{
 					Summary: StringMatchRuleConfig{Contains: "schedule: oncall"},
 				},
 				Transform: EventTransformRules{
@@ -95,7 +95,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 					{
 						Description: "Remove canceled events",
 						RemoveEvent: true,
-						Match: EventMatchRules{
+						Match: EventMatchRulesConfig{
 							Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 						},
 					},
@@ -112,7 +112,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 					{
 						Description: "Remove canceled events",
 						RemoveEvent: true,
-						Match: EventMatchRules{
+						Match: EventMatchRulesConfig{
 							Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 						},
 					},
@@ -128,7 +128,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 				Filters: mustCompileFilters(t, []FilterConfig{
 					{
 						Description: "Rename on-call events",
-						Match: EventMatchRules{
+						Match: EventMatchRulesConfig{
 							Summary: StringMatchRuleConfig{Contains: "schedule: oncall"},
 						},
 						Transform: EventTransformRules{
@@ -175,7 +175,7 @@ func TestCalendarProcessEvent(t *testing.T) {
 					{
 						Description: "Remove transformed event",
 						RemoveEvent: true,
-						Match: EventMatchRules{
+						Match: EventMatchRulesConfig{
 							Summary: StringMatchRuleConfig{Contains: "Remove"},
 						},
 					},

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ type Config struct {
 func LoadConfig(file string) (Config, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
-		return Config{}, fmt.Errorf("open config file %q: %w", file, err)
+		return Config{}, fmt.Errorf("open config file %q: %w; use -config to specify a different file", file, err)
 	}
 
 	var config Config
@@ -31,7 +31,7 @@ func LoadConfig(file string) (Config, error) {
 
 	// ensure calendars exist
 	if len(config.Calendars) == 0 {
-		return Config{}, errors.New("no calendars configured")
+		return Config{}, errors.New("no calendars configured; configuration must define at least one calendar")
 	}
 
 	// validate calendar configs and load secrets

--- a/config.go
+++ b/config.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"log/slog"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -16,22 +17,21 @@ type Config struct {
 // LoadConfig loads YAML config, resolves secret files, and validates
 // calendar-level settings. Rule compilation and regex validation happen when
 // building RuntimeConfig.
-func (config *Config) LoadConfig(file string) bool {
+func LoadConfig(file string) (Config, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
-		slog.Error("Unable to open config file! You can use -config to specify a different file", "file", file)
-		return false
+		return Config{}, fmt.Errorf("open config file %q: %w", file, err)
 	}
+
+	var config Config
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {
-		slog.Error("Error while unmarshalling yaml! Check config file is valid", "file", file)
-		return false
+		return Config{}, fmt.Errorf("parse config file %q: %w", file, err)
 	}
 
 	// ensure calendars exist
 	if len(config.Calendars) == 0 {
-		slog.Error("No calendars found! Configuration should define at least one calendar")
-		return false
+		return Config{}, errors.New("no calendars configured")
 	}
 
 	// validate calendar configs and load secrets
@@ -41,49 +41,37 @@ func (config *Config) LoadConfig(file string) bool {
 		calendarConfig := &config.Calendars[i]
 
 		if calendarConfig.Public && (calendarConfig.Token != "" || calendarConfig.TokenFile != "") {
-			slog.Error("Public calendar cannot define token or token_file", "calendar", calendarConfig.Name)
-			return false
+			return Config{}, fmt.Errorf("calendar %q: public calendar cannot define token or token_file", calendarConfig.Name)
 		}
 
 		// check if url should be loaded from file
 		if calendarConfig.FeedURLFile != "" {
 			calendarConfig.FeedURL, err = readSecretFile(calendarConfig.FeedURLFile)
 			if err != nil {
-				slog.Error("Unable to read feed_url_file", "calendar", calendarConfig.Name, "feed_url_file", calendarConfig.FeedURLFile)
-				return false
+				return Config{}, fmt.Errorf("calendar %q: read feed_url_file %q: %w", calendarConfig.Name, calendarConfig.FeedURLFile, err)
 			}
 		}
 
 		// check if url seems valid
 		if !strings.HasPrefix(calendarConfig.FeedURL, "http://") && !strings.HasPrefix(calendarConfig.FeedURL, "https://") {
-			slog.Debug("Calendar URL must begin with http:// or https://", "calendar", calendarConfig.Name, "feed_url", len(calendarConfig.Filters))
-			return false
+			return Config{}, fmt.Errorf("calendar %q: feed_url must begin with http:// or https://", calendarConfig.Name)
 		}
 
 		// check if token should be loaded from file
 		if calendarConfig.TokenFile != "" {
 			calendarConfig.Token, err = readSecretFile(calendarConfig.TokenFile)
 			if err != nil {
-				slog.Error("Unable to read token_file", "calendar", calendarConfig.Name, "token_file", calendarConfig.TokenFile)
-				return false
+				return Config{}, fmt.Errorf("calendar %q: read token_file %q: %w", calendarConfig.Name, calendarConfig.TokenFile, err)
 			}
 		}
 
-		if calendarConfig.Public {
-			slog.Warn("Calendar has no token set. Authentication will be disabled", "calendar", calendarConfig.Name)
-		} else if calendarConfig.Token == "" {
-			slog.Error("Private calendar must define token or token_file", "calendar", calendarConfig.Name)
-			return false
+		if !calendarConfig.Public && calendarConfig.Token == "" {
+			return Config{}, fmt.Errorf("calendar %q: private calendar must define token or token_file", calendarConfig.Name)
 		}
 
-		// Print a warning if the calendar has no filters
-		if len(calendarConfig.Filters) == 0 {
-			slog.Warn("Calendar has no filters and will be proxy-only", "calendar", calendarConfig.Name)
-			continue
-		}
 	}
 
-	return true // config is parsed successfully
+	return config, nil
 }
 
 func readSecretFile(filePath string) (string, error) {

--- a/config.go
+++ b/config.go
@@ -13,7 +13,9 @@ type Config struct {
 	Calendars []CalendarConfig `yaml:"calendars"`
 }
 
-// LoadConfig loads the configuration file and does basic validation.
+// LoadConfig loads YAML config, resolves secret files, and validates
+// calendar-level settings. Rule compilation and regex validation happen when
+// building RuntimeConfig.
 func (config *Config) LoadConfig(file string) bool {
 	data, err := os.ReadFile(file)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -79,36 +79,9 @@ func (config *Config) LoadConfig(file string) bool {
 			slog.Warn("Calendar has no filters and will be proxy-only", "calendar", calendarConfig.Name)
 			continue
 		}
-
-		if !calendarConfig.validateFilters() {
-			return false
-		}
 	}
 
 	return true // config is parsed successfully
-}
-
-func (calendarConfig CalendarConfig) validateFilters() bool {
-	for filterIndex, filter := range calendarConfig.Filters {
-		matchRules := []struct {
-			name string
-			rule StringMatchRule
-		}{
-			{name: "summary", rule: filter.Match.Summary},
-			{name: "description", rule: filter.Match.Description},
-			{name: "location", rule: filter.Match.Location},
-			{name: "url", rule: filter.Match.URL},
-		}
-
-		for _, matchRule := range matchRules {
-			if err := matchRule.rule.validate(); err != nil {
-				slog.Error("Invalid string match rule", "calendar", calendarConfig.Name, "filter_index", filterIndex, "property", matchRule.name, "error", err)
-				return false
-			}
-		}
-	}
-
-	return true
 }
 
 func readSecretFile(filePath string) (string, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -88,21 +88,6 @@ calendars:
 `,
 			want: false,
 		},
-		{
-			name: "invalid filter regex",
-			yaml: `
-calendars:
-  - name: public
-    public: true
-    feed_url: https://example.com/feed.ics
-    filters:
-      - description: invalid regex
-        match:
-          summary:
-            regex: "["
-`,
-			want: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -174,7 +159,10 @@ func TestConfigRuntimeConfig(t *testing.T) {
 		},
 	}
 
-	runtimeConfig := config.RuntimeConfig()
+	runtimeConfig, err := config.RuntimeConfig()
+	if err != nil {
+		t.Fatalf("RuntimeConfig() returned error: %v", err)
+	}
 
 	if len(runtimeConfig.Calendars) != 1 {
 		t.Fatalf("len(Calendars) = %d, want 1", len(runtimeConfig.Calendars))
@@ -198,6 +186,31 @@ func TestConfigRuntimeConfig(t *testing.T) {
 	}
 	if len(calendar.Filters) != 1 {
 		t.Fatalf("len(Filters) = %d, want 1", len(calendar.Filters))
+	}
+}
+
+func TestConfigRuntimeConfigRejectsInvalidRegex(t *testing.T) {
+	config := Config{
+		Calendars: []CalendarConfig{
+			{
+				Name:    "public",
+				Public:  true,
+				FeedURL: "https://example.com/feed.ics",
+				Filters: []Filter{
+					{
+						Description: "invalid regex",
+						Match: EventMatchRules{
+							Summary: StringMatchRule{RegexMatch: "["},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := config.RuntimeConfig()
+	if err == nil {
+		t.Fatal("RuntimeConfig() returned nil error")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -147,7 +147,7 @@ func TestConfigRuntimeConfig(t *testing.T) {
 				TokenFile:   "/run/secrets/token",
 				FeedURL:     "https://example.com/feed.ics",
 				FeedURLFile: "/run/secrets/feed-url",
-				Filters: []Filter{
+				Filters: []FilterConfig{
 					{
 						Description: "rename event",
 						Transform: EventTransformRules{
@@ -196,7 +196,7 @@ func TestConfigRuntimeConfigRejectsInvalidRegex(t *testing.T) {
 				Name:    "public",
 				Public:  true,
 				FeedURL: "https://example.com/feed.ics",
-				Filters: []Filter{
+				Filters: []FilterConfig{
 					{
 						Description: "invalid regex",
 						Match: EventMatchRules{

--- a/config_test.go
+++ b/config_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	tests := []struct {
-		name string
-		yaml string
-		want bool
+		name    string
+		yaml    string
+		wantErr bool
 	}{
 		{
 			name: "valid public calendar",
@@ -21,7 +21,7 @@ calendars:
     public: true
     feed_url: https://example.com/feed.ics
 `,
-			want: true,
+			wantErr: false,
 		},
 		{
 			name: "valid token calendar",
@@ -31,12 +31,12 @@ calendars:
     token: secret
     feed_url: https://example.com/feed.ics
 `,
-			want: true,
+			wantErr: false,
 		},
 		{
-			name: "empty config",
-			yaml: `{}`,
-			want: false,
+			name:    "empty config",
+			yaml:    `{}`,
+			wantErr: true,
 		},
 		{
 			name: "invalid feed url",
@@ -46,7 +46,7 @@ calendars:
     public: true
     feed_url: ftp://example.com/feed.ics
 `,
-			want: false,
+			wantErr: true,
 		},
 		{
 			name: "tokenless non-public calendar",
@@ -55,7 +55,7 @@ calendars:
   - name: private
     feed_url: https://example.com/feed.ics
 `,
-			want: false,
+			wantErr: true,
 		},
 		{
 			name: "public calendar with token",
@@ -66,7 +66,7 @@ calendars:
     token: secret
     feed_url: https://example.com/feed.ics
 `,
-			want: false,
+			wantErr: true,
 		},
 		{
 			name: "public calendar with token_file",
@@ -77,7 +77,7 @@ calendars:
     token_file: /run/secrets/token
     feed_url: https://example.com/feed.ics
 `,
-			want: false,
+			wantErr: true,
 		},
 		{
 			name: "invalid yaml",
@@ -87,7 +87,7 @@ calendars:
     public: true
     feed_url: [
 `,
-			want: false,
+			wantErr: true,
 		},
 	}
 
@@ -95,20 +95,18 @@ calendars:
 		t.Run(tt.name, func(t *testing.T) {
 			configFile := writeTempFile(t, "config-*.yaml", tt.yaml)
 
-			var config Config
-			got := config.LoadConfig(configFile)
-			if got != tt.want {
-				t.Fatalf("LoadConfig() = %v, want %v", got, tt.want)
+			_, err := LoadConfig(configFile)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("LoadConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
 func TestLoadConfigMissingFile(t *testing.T) {
-	var config Config
-	got := config.LoadConfig(filepath.Join(t.TempDir(), "missing.yaml"))
-	if got {
-		t.Fatal("LoadConfig() = true, want false")
+	_, err := LoadConfig(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err == nil {
+		t.Fatal("LoadConfig() returned nil error")
 	}
 }
 
@@ -124,9 +122,9 @@ calendars:
     feed_url_file: `+feedURLFile+`
 `)
 
-	var config Config
-	if !config.LoadConfig(configFile) {
-		t.Fatal("LoadConfig() = false, want true")
+	config, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("LoadConfig() returned error: %v", err)
 	}
 
 	if got := config.Calendars[0].Token; got != "file-token" {
@@ -267,10 +265,9 @@ calendars:
 		t.Run(tt.name, func(t *testing.T) {
 			configFile := writeTempFile(t, "config-*.yaml", tt.yaml)
 
-			var config Config
-			got := config.LoadConfig(configFile)
-			if got {
-				t.Fatal("LoadConfig() = true, want false")
+			_, err := LoadConfig(configFile)
+			if err == nil {
+				t.Fatal("LoadConfig() returned nil error")
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -200,7 +200,7 @@ func TestConfigRuntimeConfigRejectsInvalidRegex(t *testing.T) {
 					{
 						Description: "invalid regex",
 						Match: EventMatchRules{
-							Summary: StringMatchRule{RegexMatch: "["},
+							Summary: StringMatchRuleConfig{RegexMatch: "["},
 						},
 					},
 				},

--- a/config_test.go
+++ b/config_test.go
@@ -199,7 +199,7 @@ func TestConfigRuntimeConfigRejectsInvalidRegex(t *testing.T) {
 				Filters: []FilterConfig{
 					{
 						Description: "invalid regex",
-						Match: EventMatchRules{
+						Match: EventMatchRulesConfig{
 							Summary: StringMatchRuleConfig{RegexMatch: "["},
 						},
 					},

--- a/config_test.go
+++ b/config_test.go
@@ -136,7 +136,7 @@ calendars:
 	}
 }
 
-func TestConfigRuntimeConfig(t *testing.T) {
+func TestConfigCompile(t *testing.T) {
 	config := Config{
 		Calendars: []CalendarConfig{
 			{
@@ -159,9 +159,9 @@ func TestConfigRuntimeConfig(t *testing.T) {
 		},
 	}
 
-	runtimeConfig, err := config.RuntimeConfig()
+	runtimeConfig, err := config.Compile()
 	if err != nil {
-		t.Fatalf("RuntimeConfig() returned error: %v", err)
+		t.Fatalf("Compile() returned error: %v", err)
 	}
 
 	if len(runtimeConfig.Calendars) != 1 {
@@ -189,7 +189,7 @@ func TestConfigRuntimeConfig(t *testing.T) {
 	}
 }
 
-func TestConfigRuntimeConfigRejectsInvalidRegex(t *testing.T) {
+func TestConfigCompileRejectsInvalidRegex(t *testing.T) {
 	config := Config{
 		Calendars: []CalendarConfig{
 			{
@@ -208,9 +208,9 @@ func TestConfigRuntimeConfigRejectsInvalidRegex(t *testing.T) {
 		},
 	}
 
-	_, err := config.RuntimeConfig()
+	_, err := config.Compile()
 	if err == nil {
-		t.Fatal("RuntimeConfig() returned nil error")
+		t.Fatal("Compile() returned nil error")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -211,6 +212,9 @@ func TestConfigCompileRejectsInvalidRegex(t *testing.T) {
 	_, err := config.Compile()
 	if err == nil {
 		t.Fatal("Compile() returned nil error")
+	}
+	if !strings.Contains(err.Error(), `calendar "public" filter 0`) || !strings.Contains(err.Error(), `summary: invalid regex`) {
+		t.Fatalf("Compile() error = %q, want calendar/filter/property context", err)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -151,6 +151,56 @@ calendars:
 	}
 }
 
+func TestConfigRuntimeConfig(t *testing.T) {
+	config := Config{
+		Calendars: []CalendarConfig{
+			{
+				Name:        "private",
+				PublishName: "Published Calendar",
+				Public:      false,
+				Token:       "secret",
+				TokenFile:   "/run/secrets/token",
+				FeedURL:     "https://example.com/feed.ics",
+				FeedURLFile: "/run/secrets/feed-url",
+				Filters: []Filter{
+					{
+						Description: "rename event",
+						Transform: EventTransformRules{
+							Summary: StringTransformRule{Replace: "renamed"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runtimeConfig := config.RuntimeConfig()
+
+	if len(runtimeConfig.Calendars) != 1 {
+		t.Fatalf("len(Calendars) = %d, want 1", len(runtimeConfig.Calendars))
+	}
+
+	calendar := runtimeConfig.Calendars[0]
+	if calendar.Name != "private" {
+		t.Fatalf("Name = %q, want private", calendar.Name)
+	}
+	if calendar.PublishName != "Published Calendar" {
+		t.Fatalf("PublishName = %q, want Published Calendar", calendar.PublishName)
+	}
+	if calendar.Public {
+		t.Fatal("Public = true, want false")
+	}
+	if calendar.Token != "secret" {
+		t.Fatalf("Token = %q, want secret", calendar.Token)
+	}
+	if calendar.FeedURL != "https://example.com/feed.ics" {
+		t.Fatalf("FeedURL = %q, want https://example.com/feed.ics", calendar.FeedURL)
+	}
+	if len(calendar.Filters) != 1 {
+		t.Fatalf("len(Filters) = %d, want 1", len(calendar.Filters))
+	}
+}
+
 func TestLoadConfigRejectsMissingSecretFiles(t *testing.T) {
 	tests := []struct {
 		name string

--- a/filter.go
+++ b/filter.go
@@ -6,7 +6,8 @@ import (
 	ics "github.com/arran4/golang-ical"
 )
 
-// Filter definition
+// Filter is the YAML-backed filter configuration. It is compiled into
+// CompiledFilter before runtime event processing.
 type Filter struct {
 	Description string              `yaml:"description"`
 	RemoveEvent bool                `yaml:"remove"`
@@ -15,6 +16,9 @@ type Filter struct {
 	Transform   EventTransformRules `yaml:"transform"`
 }
 
+// CompiledFilter is the runtime filter representation. Match rules are compiled
+// once during config preparation; transforms remain raw because they are already
+// directly executable.
 type CompiledFilter struct {
 	Description string
 	RemoveEvent bool
@@ -81,7 +85,7 @@ func (filter CompiledFilter) transformEvent(event *ics.VEvent) {
 	}
 }
 
-// EventMatchRules contains VEvent properties that user can match against
+// EventMatchRules contains YAML-backed match rules for VEvent properties.
 type EventMatchRules struct {
 	Summary     StringMatchRule `yaml:"summary"`
 	Description StringMatchRule `yaml:"description"`
@@ -89,6 +93,8 @@ type EventMatchRules struct {
 	URL         StringMatchRule `yaml:"url"`
 }
 
+// CompiledEventMatchRules contains runtime-ready match rules for VEvent
+// properties.
 type CompiledEventMatchRules struct {
 	Summary     CompiledStringMatchRule
 	Description CompiledStringMatchRule

--- a/filter.go
+++ b/filter.go
@@ -6,9 +6,9 @@ import (
 	ics "github.com/arran4/golang-ical"
 )
 
-// Filter is the YAML-backed filter configuration. It is compiled into
-// CompiledFilter before runtime event processing.
-type Filter struct {
+// FilterConfig is the YAML-backed filter configuration. It is compiled into
+// Filter before runtime event processing.
+type FilterConfig struct {
 	Description string              `yaml:"description"`
 	RemoveEvent bool                `yaml:"remove"`
 	Stop        bool                `yaml:"stop"`
@@ -16,10 +16,10 @@ type Filter struct {
 	Transform   EventTransformRules `yaml:"transform"`
 }
 
-// CompiledFilter is the runtime filter representation. Match rules are compiled
+// Filter is the runtime filter representation. Match rules are compiled
 // once during config preparation; transforms remain raw because they are already
 // directly executable.
-type CompiledFilter struct {
+type Filter struct {
 	Description string
 	RemoveEvent bool
 	Stop        bool
@@ -27,13 +27,13 @@ type CompiledFilter struct {
 	Transform   EventTransformRules
 }
 
-func (filter Filter) compile() (CompiledFilter, error) {
+func (filter FilterConfig) compile() (Filter, error) {
 	match, err := filter.Match.compile()
 	if err != nil {
-		return CompiledFilter{}, err
+		return Filter{}, err
 	}
 
-	return CompiledFilter{
+	return Filter{
 		Description: filter.Description,
 		RemoveEvent: filter.RemoveEvent,
 		Stop:        filter.Stop,
@@ -43,7 +43,7 @@ func (filter Filter) compile() (CompiledFilter, error) {
 }
 
 // Returns true if a VEvent matches the Filter conditions
-func (filter CompiledFilter) matchesEvent(event ics.VEvent) bool {
+func (filter Filter) matchesEvent(event ics.VEvent) bool {
 
 	// If an event property is not defined golang-ical returns a nil pointer
 
@@ -73,7 +73,7 @@ func (filter CompiledFilter) matchesEvent(event ics.VEvent) bool {
 }
 
 // Applies filter transformations to a VEvent pointer
-func (filter CompiledFilter) transformEvent(event *ics.VEvent) {
+func (filter Filter) transformEvent(event *ics.VEvent) {
 	stringTransforms := []eventStringTransform{
 		{property: ics.ComponentPropertySummary, rule: filter.Transform.Summary, set: func(value string) { event.SetSummary(value) }},
 		{property: ics.ComponentPropertyDescription, rule: filter.Transform.Description, set: func(value string) { event.SetDescription(value) }},

--- a/filter.go
+++ b/filter.go
@@ -9,11 +9,11 @@ import (
 // FilterConfig is the YAML-backed filter configuration. It is compiled into
 // Filter before runtime event processing.
 type FilterConfig struct {
-	Description string              `yaml:"description"`
-	RemoveEvent bool                `yaml:"remove"`
-	Stop        bool                `yaml:"stop"`
-	Match       EventMatchRules     `yaml:"match"`
-	Transform   EventTransformRules `yaml:"transform"`
+	Description string                `yaml:"description"`
+	RemoveEvent bool                  `yaml:"remove"`
+	Stop        bool                  `yaml:"stop"`
+	Match       EventMatchRulesConfig `yaml:"match"`
+	Transform   EventTransformRules   `yaml:"transform"`
 }
 
 // Filter is the runtime filter representation. Match rules are compiled
@@ -23,7 +23,7 @@ type Filter struct {
 	Description string
 	RemoveEvent bool
 	Stop        bool
-	Match       CompiledEventMatchRules
+	Match       EventMatchRules
 	Transform   EventTransformRules
 }
 
@@ -85,42 +85,42 @@ func (filter Filter) transformEvent(event *ics.VEvent) {
 	}
 }
 
-// EventMatchRules contains YAML-backed match rules for VEvent properties.
-type EventMatchRules struct {
+// EventMatchRulesConfig contains YAML-backed match rules for VEvent properties.
+type EventMatchRulesConfig struct {
 	Summary     StringMatchRuleConfig `yaml:"summary"`
 	Description StringMatchRuleConfig `yaml:"description"`
 	Location    StringMatchRuleConfig `yaml:"location"`
 	URL         StringMatchRuleConfig `yaml:"url"`
 }
 
-// CompiledEventMatchRules contains runtime-ready match rules for VEvent
+// EventMatchRules contains runtime-ready match rules for VEvent
 // properties.
-type CompiledEventMatchRules struct {
+type EventMatchRules struct {
 	Summary     StringMatchRule
 	Description StringMatchRule
 	Location    StringMatchRule
 	URL         StringMatchRule
 }
 
-func (rules EventMatchRules) compile() (CompiledEventMatchRules, error) {
+func (rules EventMatchRulesConfig) compile() (EventMatchRules, error) {
 	summary, err := rules.Summary.compile()
 	if err != nil {
-		return CompiledEventMatchRules{}, err
+		return EventMatchRules{}, err
 	}
 	description, err := rules.Description.compile()
 	if err != nil {
-		return CompiledEventMatchRules{}, err
+		return EventMatchRules{}, err
 	}
 	location, err := rules.Location.compile()
 	if err != nil {
-		return CompiledEventMatchRules{}, err
+		return EventMatchRules{}, err
 	}
 	url, err := rules.URL.compile()
 	if err != nil {
-		return CompiledEventMatchRules{}, err
+		return EventMatchRules{}, err
 	}
 
-	return CompiledEventMatchRules{
+	return EventMatchRules{
 		Summary:     summary,
 		Description: description,
 		Location:    location,

--- a/filter.go
+++ b/filter.go
@@ -87,19 +87,19 @@ func (filter Filter) transformEvent(event *ics.VEvent) {
 
 // EventMatchRules contains YAML-backed match rules for VEvent properties.
 type EventMatchRules struct {
-	Summary     StringMatchRule `yaml:"summary"`
-	Description StringMatchRule `yaml:"description"`
-	Location    StringMatchRule `yaml:"location"`
-	URL         StringMatchRule `yaml:"url"`
+	Summary     StringMatchRuleConfig `yaml:"summary"`
+	Description StringMatchRuleConfig `yaml:"description"`
+	Location    StringMatchRuleConfig `yaml:"location"`
+	URL         StringMatchRuleConfig `yaml:"url"`
 }
 
 // CompiledEventMatchRules contains runtime-ready match rules for VEvent
 // properties.
 type CompiledEventMatchRules struct {
-	Summary     CompiledStringMatchRule
-	Description CompiledStringMatchRule
-	Location    CompiledStringMatchRule
-	URL         CompiledStringMatchRule
+	Summary     StringMatchRule
+	Description StringMatchRule
+	Location    StringMatchRule
+	URL         StringMatchRule
 }
 
 func (rules EventMatchRules) compile() (CompiledEventMatchRules, error) {
@@ -139,7 +139,7 @@ type EventTransformRules struct {
 type eventStringMatch struct {
 	property ics.ComponentProperty
 	name     string
-	rule     CompiledStringMatchRule
+	rule     StringMatchRule
 }
 
 type eventStringTransform struct {
@@ -148,7 +148,7 @@ type eventStringTransform struct {
 	set      func(string)
 }
 
-func eventStringPropertyMatches(event ics.VEvent, property ics.ComponentProperty, rule CompiledStringMatchRule) bool {
+func eventStringPropertyMatches(event ics.VEvent, property ics.ComponentProperty, rule StringMatchRule) bool {
 	if !rule.hasConditions() {
 		return true
 	}

--- a/filter.go
+++ b/filter.go
@@ -15,8 +15,31 @@ type Filter struct {
 	Transform   EventTransformRules `yaml:"transform"`
 }
 
+type CompiledFilter struct {
+	Description string
+	RemoveEvent bool
+	Stop        bool
+	Match       CompiledEventMatchRules
+	Transform   EventTransformRules
+}
+
+func (filter Filter) compile() (CompiledFilter, error) {
+	match, err := filter.Match.compile()
+	if err != nil {
+		return CompiledFilter{}, err
+	}
+
+	return CompiledFilter{
+		Description: filter.Description,
+		RemoveEvent: filter.RemoveEvent,
+		Stop:        filter.Stop,
+		Match:       match,
+		Transform:   filter.Transform,
+	}, nil
+}
+
 // Returns true if a VEvent matches the Filter conditions
-func (filter Filter) matchesEvent(event ics.VEvent) bool {
+func (filter CompiledFilter) matchesEvent(event ics.VEvent) bool {
 
 	// If an event property is not defined golang-ical returns a nil pointer
 
@@ -46,7 +69,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 }
 
 // Applies filter transformations to a VEvent pointer
-func (filter Filter) transformEvent(event *ics.VEvent) {
+func (filter CompiledFilter) transformEvent(event *ics.VEvent) {
 	stringTransforms := []eventStringTransform{
 		{property: ics.ComponentPropertySummary, rule: filter.Transform.Summary, set: func(value string) { event.SetSummary(value) }},
 		{property: ics.ComponentPropertyDescription, rule: filter.Transform.Description, set: func(value string) { event.SetDescription(value) }},
@@ -66,6 +89,39 @@ type EventMatchRules struct {
 	URL         StringMatchRule `yaml:"url"`
 }
 
+type CompiledEventMatchRules struct {
+	Summary     CompiledStringMatchRule
+	Description CompiledStringMatchRule
+	Location    CompiledStringMatchRule
+	URL         CompiledStringMatchRule
+}
+
+func (rules EventMatchRules) compile() (CompiledEventMatchRules, error) {
+	summary, err := rules.Summary.compile()
+	if err != nil {
+		return CompiledEventMatchRules{}, err
+	}
+	description, err := rules.Description.compile()
+	if err != nil {
+		return CompiledEventMatchRules{}, err
+	}
+	location, err := rules.Location.compile()
+	if err != nil {
+		return CompiledEventMatchRules{}, err
+	}
+	url, err := rules.URL.compile()
+	if err != nil {
+		return CompiledEventMatchRules{}, err
+	}
+
+	return CompiledEventMatchRules{
+		Summary:     summary,
+		Description: description,
+		Location:    location,
+		URL:         url,
+	}, nil
+}
+
 // EventTransformRules contains VEvent properties that user can modify
 type EventTransformRules struct {
 	Summary     StringTransformRule `yaml:"summary"`
@@ -77,7 +133,7 @@ type EventTransformRules struct {
 type eventStringMatch struct {
 	property ics.ComponentProperty
 	name     string
-	rule     StringMatchRule
+	rule     CompiledStringMatchRule
 }
 
 type eventStringTransform struct {
@@ -86,7 +142,7 @@ type eventStringTransform struct {
 	set      func(string)
 }
 
-func eventStringPropertyMatches(event ics.VEvent, property ics.ComponentProperty, rule StringMatchRule) bool {
+func eventStringPropertyMatches(event ics.VEvent, property ics.ComponentProperty, rule CompiledStringMatchRule) bool {
 	if !rule.hasConditions() {
 		return true
 	}

--- a/filter.go
+++ b/filter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 
 	ics "github.com/arran4/golang-ical"
@@ -105,19 +106,19 @@ type EventMatchRules struct {
 func (rules EventMatchRulesConfig) compile() (EventMatchRules, error) {
 	summary, err := rules.Summary.compile()
 	if err != nil {
-		return EventMatchRules{}, err
+		return EventMatchRules{}, fmt.Errorf("summary: %w", err)
 	}
 	description, err := rules.Description.compile()
 	if err != nil {
-		return EventMatchRules{}, err
+		return EventMatchRules{}, fmt.Errorf("description: %w", err)
 	}
 	location, err := rules.Location.compile()
 	if err != nil {
-		return EventMatchRules{}, err
+		return EventMatchRules{}, fmt.Errorf("location: %w", err)
 	}
 	url, err := rules.URL.compile()
 	if err != nil {
-		return EventMatchRules{}, err
+		return EventMatchRules{}, fmt.Errorf("url: %w", err)
 	}
 
 	return EventMatchRules{

--- a/filter_test.go
+++ b/filter_test.go
@@ -10,19 +10,19 @@ func TestFilterMatchesEvent(t *testing.T) {
 	tests := []struct {
 		name  string
 		event *ics.VEvent
-		match EventMatchRules
+		match EventMatchRulesConfig
 		want  bool
 	}{
 		{
 			name:  "filter without match rules matches event",
 			event: testEvent("team calendar event"),
-			match: EventMatchRules{},
+			match: EventMatchRulesConfig{},
 			want:  true,
 		},
 		{
 			name:  "summary matches",
 			event: testEvent("Canceled: team calendar event"),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 			},
 			want: true,
@@ -30,7 +30,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 		{
 			name:  "summary mismatch rejects event",
 			event: testEvent("team calendar event"),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 			},
 			want: false,
@@ -40,7 +40,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			event: testEvent("team calendar event", func(event *ics.VEvent) {
 				event.SetDescription("weekday shift")
 			}),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Description: StringMatchRuleConfig{Contains: "shift"},
 			},
 			want: true,
@@ -48,7 +48,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 		{
 			name:  "missing description matches empty",
 			event: testEvent("team calendar event"),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Description: StringMatchRuleConfig{Null: true},
 			},
 			want: true,
@@ -58,7 +58,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			event: testEvent("team calendar event", func(event *ics.VEvent) {
 				event.SetLocation("Adelaide")
 			}),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Location: StringMatchRuleConfig{Suffix: "laide"},
 			},
 			want: true,
@@ -66,7 +66,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 		{
 			name:  "missing location matches empty",
 			event: testEvent("team calendar event"),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Location: StringMatchRuleConfig{Null: true},
 			},
 			want: true,
@@ -76,7 +76,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			event: testEvent("team calendar event", func(event *ics.VEvent) {
 				event.SetURL("https://example.com/event")
 			}),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				URL: StringMatchRuleConfig{Contains: "example.com"},
 			},
 			want: true,
@@ -84,7 +84,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 		{
 			name:  "missing url matches empty",
 			event: testEvent("team calendar event"),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				URL: StringMatchRuleConfig{Null: true},
 			},
 			want: true,
@@ -96,7 +96,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetLocation("Adelaide")
 				event.SetURL("https://example.com/event")
 			}),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Summary:     StringMatchRuleConfig{Contains: "calendar"},
 				Description: StringMatchRuleConfig{Contains: "shift"},
 				Location:    StringMatchRuleConfig{Prefix: "Adel"},
@@ -111,7 +111,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetLocation("Adelaide")
 				event.SetURL("https://example.com/event")
 			}),
-			match: EventMatchRules{
+			match: EventMatchRulesConfig{
 				Summary:     StringMatchRuleConfig{Contains: "calendar"},
 				Description: StringMatchRuleConfig{Contains: "holiday"},
 				Location:    StringMatchRuleConfig{Prefix: "Adel"},
@@ -122,7 +122,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 		{
 			name:  "event without summary never matches",
 			event: ics.NewEvent("missing-summary"),
-			match: EventMatchRules{},
+			match: EventMatchRulesConfig{},
 			want:  false,
 		},
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -23,7 +23,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			name:  "summary matches",
 			event: testEvent("Canceled: team calendar event"),
 			match: EventMatchRules{
-				Summary: StringMatchRule{Prefix: "Canceled: "},
+				Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 			},
 			want: true,
 		},
@@ -31,7 +31,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			name:  "summary mismatch rejects event",
 			event: testEvent("team calendar event"),
 			match: EventMatchRules{
-				Summary: StringMatchRule{Prefix: "Canceled: "},
+				Summary: StringMatchRuleConfig{Prefix: "Canceled: "},
 			},
 			want: false,
 		},
@@ -41,7 +41,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetDescription("weekday shift")
 			}),
 			match: EventMatchRules{
-				Description: StringMatchRule{Contains: "shift"},
+				Description: StringMatchRuleConfig{Contains: "shift"},
 			},
 			want: true,
 		},
@@ -49,7 +49,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			name:  "missing description matches empty",
 			event: testEvent("team calendar event"),
 			match: EventMatchRules{
-				Description: StringMatchRule{Null: true},
+				Description: StringMatchRuleConfig{Null: true},
 			},
 			want: true,
 		},
@@ -59,7 +59,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetLocation("Adelaide")
 			}),
 			match: EventMatchRules{
-				Location: StringMatchRule{Suffix: "laide"},
+				Location: StringMatchRuleConfig{Suffix: "laide"},
 			},
 			want: true,
 		},
@@ -67,7 +67,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			name:  "missing location matches empty",
 			event: testEvent("team calendar event"),
 			match: EventMatchRules{
-				Location: StringMatchRule{Null: true},
+				Location: StringMatchRuleConfig{Null: true},
 			},
 			want: true,
 		},
@@ -77,7 +77,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetURL("https://example.com/event")
 			}),
 			match: EventMatchRules{
-				URL: StringMatchRule{Contains: "example.com"},
+				URL: StringMatchRuleConfig{Contains: "example.com"},
 			},
 			want: true,
 		},
@@ -85,7 +85,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 			name:  "missing url matches empty",
 			event: testEvent("team calendar event"),
 			match: EventMatchRules{
-				URL: StringMatchRule{Null: true},
+				URL: StringMatchRuleConfig{Null: true},
 			},
 			want: true,
 		},
@@ -97,10 +97,10 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetURL("https://example.com/event")
 			}),
 			match: EventMatchRules{
-				Summary:     StringMatchRule{Contains: "calendar"},
-				Description: StringMatchRule{Contains: "shift"},
-				Location:    StringMatchRule{Prefix: "Adel"},
-				URL:         StringMatchRule{Suffix: "/event"},
+				Summary:     StringMatchRuleConfig{Contains: "calendar"},
+				Description: StringMatchRuleConfig{Contains: "shift"},
+				Location:    StringMatchRuleConfig{Prefix: "Adel"},
+				URL:         StringMatchRuleConfig{Suffix: "/event"},
 			},
 			want: true,
 		},
@@ -112,10 +112,10 @@ func TestFilterMatchesEvent(t *testing.T) {
 				event.SetURL("https://example.com/event")
 			}),
 			match: EventMatchRules{
-				Summary:     StringMatchRule{Contains: "calendar"},
-				Description: StringMatchRule{Contains: "holiday"},
-				Location:    StringMatchRule{Prefix: "Adel"},
-				URL:         StringMatchRule{Suffix: "/event"},
+				Summary:     StringMatchRuleConfig{Contains: "calendar"},
+				Description: StringMatchRuleConfig{Contains: "holiday"},
+				Location:    StringMatchRuleConfig{Prefix: "Adel"},
+				URL:         StringMatchRuleConfig{Suffix: "/event"},
 			},
 			want: false,
 		},
@@ -154,35 +154,35 @@ func TestEventStringPropertyMatches(t *testing.T) {
 		name     string
 		event    *ics.VEvent
 		property ics.ComponentProperty
-		rule     CompiledStringMatchRule
+		rule     StringMatchRule
 		want     bool
 	}{
 		{
 			name:     "empty rule matches",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertySummary,
-			rule:     mustCompileStringMatchRule(t, StringMatchRule{}),
+			rule:     mustCompileStringMatchRule(t, StringMatchRuleConfig{}),
 			want:     true,
 		},
 		{
 			name:     "property value matches",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertySummary,
-			rule:     mustCompileStringMatchRule(t, StringMatchRule{Contains: "calendar"}),
+			rule:     mustCompileStringMatchRule(t, StringMatchRuleConfig{Contains: "calendar"}),
 			want:     true,
 		},
 		{
 			name:     "property value mismatch",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertySummary,
-			rule:     mustCompileStringMatchRule(t, StringMatchRule{Contains: "holiday"}),
+			rule:     mustCompileStringMatchRule(t, StringMatchRuleConfig{Contains: "holiday"}),
 			want:     false,
 		},
 		{
 			name:     "missing property matches empty rule",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertyDescription,
-			rule:     mustCompileStringMatchRule(t, StringMatchRule{Null: true}),
+			rule:     mustCompileStringMatchRule(t, StringMatchRuleConfig{Null: true}),
 			want:     true,
 		},
 	}
@@ -360,7 +360,7 @@ func mustCompileFilters(t *testing.T, filters []FilterConfig) []Filter {
 	return compiledFilters
 }
 
-func mustCompileStringMatchRule(t *testing.T, rule StringMatchRule) CompiledStringMatchRule {
+func mustCompileStringMatchRule(t *testing.T, rule StringMatchRuleConfig) StringMatchRule {
 	t.Helper()
 
 	compiledRule, err := rule.compile()

--- a/filter_test.go
+++ b/filter_test.go
@@ -129,7 +129,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filter := mustCompileFilter(t, Filter{Match: tt.match})
+			filter := mustCompileFilter(t, FilterConfig{Match: tt.match})
 			got := filter.matchesEvent(*tt.event)
 			if got != tt.want {
 				t.Fatalf("matchesEvent() = %v, want %v", got, tt.want)
@@ -311,7 +311,7 @@ func TestFilterTransformEvent(t *testing.T) {
 				event.SetURL("https://example.com/original")
 			})
 
-			filter := mustCompileFilter(t, Filter{Transform: tt.transform})
+			filter := mustCompileFilter(t, FilterConfig{Transform: tt.transform})
 			filter.transformEvent(event)
 
 			for property, want := range tt.want {
@@ -338,7 +338,7 @@ func testEvent(summary string, options ...func(*ics.VEvent)) *ics.VEvent {
 	return event
 }
 
-func mustCompileFilter(t *testing.T, filter Filter) CompiledFilter {
+func mustCompileFilter(t *testing.T, filter FilterConfig) Filter {
 	t.Helper()
 
 	compiledFilter, err := filter.compile()
@@ -349,10 +349,10 @@ func mustCompileFilter(t *testing.T, filter Filter) CompiledFilter {
 	return compiledFilter
 }
 
-func mustCompileFilters(t *testing.T, filters []Filter) []CompiledFilter {
+func mustCompileFilters(t *testing.T, filters []FilterConfig) []Filter {
 	t.Helper()
 
-	compiledFilters := make([]CompiledFilter, 0, len(filters))
+	compiledFilters := make([]Filter, 0, len(filters))
 	for _, filter := range filters {
 		compiledFilters = append(compiledFilters, mustCompileFilter(t, filter))
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -129,7 +129,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filter := Filter{Match: tt.match}
+			filter := mustCompileFilter(t, Filter{Match: tt.match})
 			got := filter.matchesEvent(*tt.event)
 			if got != tt.want {
 				t.Fatalf("matchesEvent() = %v, want %v", got, tt.want)
@@ -154,35 +154,35 @@ func TestEventStringPropertyMatches(t *testing.T) {
 		name     string
 		event    *ics.VEvent
 		property ics.ComponentProperty
-		rule     StringMatchRule
+		rule     CompiledStringMatchRule
 		want     bool
 	}{
 		{
 			name:     "empty rule matches",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertySummary,
-			rule:     StringMatchRule{},
+			rule:     mustCompileStringMatchRule(t, StringMatchRule{}),
 			want:     true,
 		},
 		{
 			name:     "property value matches",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertySummary,
-			rule:     StringMatchRule{Contains: "calendar"},
+			rule:     mustCompileStringMatchRule(t, StringMatchRule{Contains: "calendar"}),
 			want:     true,
 		},
 		{
 			name:     "property value mismatch",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertySummary,
-			rule:     StringMatchRule{Contains: "holiday"},
+			rule:     mustCompileStringMatchRule(t, StringMatchRule{Contains: "holiday"}),
 			want:     false,
 		},
 		{
 			name:     "missing property matches empty rule",
 			event:    testEvent("team calendar event"),
 			property: ics.ComponentPropertyDescription,
-			rule:     StringMatchRule{Null: true},
+			rule:     mustCompileStringMatchRule(t, StringMatchRule{Null: true}),
 			want:     true,
 		},
 	}
@@ -311,7 +311,7 @@ func TestFilterTransformEvent(t *testing.T) {
 				event.SetURL("https://example.com/original")
 			})
 
-			filter := Filter{Transform: tt.transform}
+			filter := mustCompileFilter(t, Filter{Transform: tt.transform})
 			filter.transformEvent(event)
 
 			for property, want := range tt.want {
@@ -336,4 +336,37 @@ func testEvent(summary string, options ...func(*ics.VEvent)) *ics.VEvent {
 	}
 
 	return event
+}
+
+func mustCompileFilter(t *testing.T, filter Filter) CompiledFilter {
+	t.Helper()
+
+	compiledFilter, err := filter.compile()
+	if err != nil {
+		t.Fatalf("compile() returned error: %v", err)
+	}
+
+	return compiledFilter
+}
+
+func mustCompileFilters(t *testing.T, filters []Filter) []CompiledFilter {
+	t.Helper()
+
+	compiledFilters := make([]CompiledFilter, 0, len(filters))
+	for _, filter := range filters {
+		compiledFilters = append(compiledFilters, mustCompileFilter(t, filter))
+	}
+
+	return compiledFilters
+}
+
+func mustCompileStringMatchRule(t *testing.T, rule StringMatchRule) CompiledStringMatchRule {
+	t.Helper()
+
+	compiledRule, err := rule.compile()
+	if err != nil {
+		t.Fatalf("compile() returned error: %v", err)
+	}
+
+	return compiledRule
 }

--- a/handler.go
+++ b/handler.go
@@ -15,7 +15,7 @@ const (
 
 type calendarFetchFunc func(context.Context) ([]byte, error)
 
-func calendarFeedHandlerWithFetch(calendarConfig CalendarConfig, fetch calendarFetchFunc) http.HandlerFunc {
+func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setCommonResponseHeaders(w)
 
@@ -25,7 +25,7 @@ func calendarFeedHandlerWithFetch(calendarConfig CalendarConfig, fetch calendarF
 			return
 		}
 
-		if !calendarConfig.Public && !tokenMatches(r.URL.Query().Get("token"), calendarConfig.Token) {
+		if !calendar.Public && !tokenMatches(r.URL.Query().Get("token"), calendar.Token) {
 			slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return

--- a/handler.go
+++ b/handler.go
@@ -59,6 +59,8 @@ func setCommonResponseHeaders(w http.ResponseWriter) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
+// tokenMatches compares tokens without short-circuiting on the first different
+// byte.
 func tokenMatches(token string, expectedToken string) bool {
 	return subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -54,7 +54,7 @@ func TestTokenMatches(t *testing.T) {
 func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
 	fetchCalled := false
 	handler := calendarFeedHandlerWithFetch(
-		CalendarConfig{Name: "private", Token: "secret"},
+		Calendar{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			fetchCalled = true
 			return []byte("should not be called"), nil
@@ -77,7 +77,7 @@ func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
 
 func TestCalendarFeedHandlerSuccess(t *testing.T) {
 	handler := calendarFeedHandlerWithFetch(
-		CalendarConfig{Name: "private", Token: "secret"},
+		Calendar{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
 		},
@@ -102,7 +102,7 @@ func TestCalendarFeedHandlerSuccess(t *testing.T) {
 
 func TestCalendarFeedHandlerHeadSuccess(t *testing.T) {
 	handler := calendarFeedHandlerWithFetch(
-		CalendarConfig{Name: "private", Token: "secret"},
+		Calendar{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
 		},
@@ -128,7 +128,7 @@ func TestCalendarFeedHandlerHeadSuccess(t *testing.T) {
 func TestCalendarFeedHandlerMethodNotAllowed(t *testing.T) {
 	fetchCalled := false
 	handler := calendarFeedHandlerWithFetch(
-		CalendarConfig{Name: "private", Token: "secret"},
+		Calendar{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			fetchCalled = true
 			return []byte("should not be called"), nil
@@ -170,7 +170,7 @@ func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := calendarFeedHandlerWithFetch(
-				CalendarConfig{Name: "public", Public: true},
+				Calendar{Name: "public", Public: true},
 				func(context.Context) ([]byte, error) {
 					return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
 				},
@@ -190,7 +190,7 @@ func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
 
 func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
 	handler := calendarFeedHandlerWithFetch(
-		CalendarConfig{Name: "private", Token: "secret"},
+		Calendar{Name: "private", Token: "secret"},
 		func(context.Context) ([]byte, error) {
 			return nil, errors.New("upstream failed")
 		},

--- a/main.go
+++ b/main.go
@@ -61,11 +61,14 @@ func main() {
 
 	// load configuration
 	slog.Debug("reading config", "configFile", configFile)
-	var config Config
-	if !config.LoadConfig(configFile) {
+	config, err := LoadConfig(configFile)
+	if err != nil {
+		slog.Error("Invalid configuration", "error", err)
 		os.Exit(1) // fail if config is not valid
 	}
 	slog.Debug("loaded config")
+
+	logConfigWarnings(config)
 
 	runtimeConfig, err := config.Compile()
 	if err != nil {
@@ -94,4 +97,15 @@ func main() {
 		os.Exit(1)
 	}
 
+}
+
+func logConfigWarnings(config Config) {
+	for _, calendar := range config.Calendars {
+		if calendar.Public {
+			slog.Warn("Calendar has no token set. Authentication will be disabled", "calendar", calendar.Name)
+		}
+		if len(calendar.Filters) == 0 {
+			slog.Warn("Calendar has no filters and will be proxy-only", "calendar", calendar.Name)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 	slog.Debug("loaded config")
 
-	runtimeConfig, err := config.RuntimeConfig()
+	runtimeConfig, err := config.Compile()
 	if err != nil {
 		slog.Error("Invalid configuration", "error", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -73,6 +73,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	runtimeConfig := config.RuntimeConfig()
+
 	var metrics *prometheusMetrics
 	if metricsEnabled {
 		metrics = newPrometheusMetrics(calendarMetricsEnabled)
@@ -82,7 +84,7 @@ func main() {
 		slog.Warn("Prometheus metrics endpoint enabled on public listener; set -management-address to expose management endpoints separately")
 	}
 
-	servers := buildHTTPServers(config, listenPort, managementAddress, metrics)
+	servers := buildHTTPServers(runtimeConfig, listenPort, managementAddress, metrics)
 	if err := runHTTPServers(servers...); err != nil {
 		slog.Error("Error running web server", "error", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -67,13 +67,17 @@ func main() {
 	}
 	slog.Debug("loaded config")
 
+	runtimeConfig, err := config.RuntimeConfig()
+	if err != nil {
+		slog.Error("Invalid configuration", "error", err)
+		os.Exit(1)
+	}
+
 	// print a message and exit if validate arg was specified
 	if validateConfig {
 		slog.Info("configuration was validated successfully")
 		os.Exit(0)
 	}
-
-	runtimeConfig := config.RuntimeConfig()
 
 	var metrics *prometheusMetrics
 	if metricsEnabled {

--- a/metrics.go
+++ b/metrics.go
@@ -218,10 +218,14 @@ func (m *prometheusMetrics) instrumentFetch(calendarName string, fetch calendarF
 }
 
 func observeHTTPDuration(route string) bool {
+	// Keep histograms focused on calendar feed requests; management and unknown
+	// routes are usually probes or mistakes and add little latency signal.
 	return route == "/calendars/{calendar}/feed"
 }
 
 func routeMetricLabel(listener string, path string) string {
+	// Normalize request paths before labelling metrics so calendar names,
+	// tokens, and arbitrary unknown paths are not exposed as label values.
 	switch {
 	case strings.HasPrefix(path, "/calendars/"):
 		return "/calendars/{calendar}/feed"

--- a/routes.go
+++ b/routes.go
@@ -5,17 +5,17 @@ import (
 	"net/http"
 )
 
-func registerPublicRoutes(mux *http.ServeMux, config Config, metrics *prometheusMetrics) {
-	for _, calendarConfig := range config.Calendars {
-		httpPath := "/calendars/" + calendarConfig.Name + "/feed"
-		slog.Debug("Configuring endpoint", "calendar", calendarConfig.Name, "http_path", httpPath)
+func registerPublicRoutes(mux *http.ServeMux, config RuntimeConfig, metrics *prometheusMetrics) {
+	for _, calendar := range config.Calendars {
+		httpPath := "/calendars/" + calendar.Name + "/feed"
+		slog.Debug("Configuring endpoint", "calendar", calendar.Name, "http_path", httpPath)
 
-		fetch := calendarConfig.fetch
+		fetch := calendar.fetch
 		if metrics != nil {
-			fetch = metrics.instrumentFetch(calendarConfig.Name, fetch)
+			fetch = metrics.instrumentFetch(calendar.Name, fetch)
 		}
 
-		mux.HandleFunc(httpPath, calendarFeedHandlerWithFetch(calendarConfig, fetch))
+		mux.HandleFunc(httpPath, calendarFeedHandlerWithFetch(calendar, fetch))
 	}
 }
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestRegisterPublicRoutesRegistersCalendarFeeds(t *testing.T) {
 	mux := http.NewServeMux()
-	registerPublicRoutes(mux, Config{
-		Calendars: []CalendarConfig{
+	registerPublicRoutes(mux, RuntimeConfig{
+		Calendars: []Calendar{
 			{
 				Name:  "private",
 				Token: "secret",
@@ -61,8 +61,8 @@ func TestRegisterInternalRoutesRegistersHealthEndpoints(t *testing.T) {
 
 func TestPublicAndInternalRoutesCanUseSeparateMuxes(t *testing.T) {
 	publicMux := http.NewServeMux()
-	registerPublicRoutes(publicMux, Config{
-		Calendars: []CalendarConfig{
+	registerPublicRoutes(publicMux, RuntimeConfig{
+		Calendars: []Calendar{
 			{
 				Name:  "private",
 				Token: "secret",

--- a/server.go
+++ b/server.go
@@ -45,7 +45,7 @@ func buildHTTPHandler(listener string, handler http.Handler, metrics *prometheus
 	return requestLoggingMiddleware(handler)
 }
 
-func buildHTTPServers(config Config, listenPort int, managementAddress string, metrics *prometheusMetrics) []managedHTTPServer {
+func buildHTTPServers(config RuntimeConfig, listenPort int, managementAddress string, metrics *prometheusMetrics) []managedHTTPServer {
 	publicMux := http.NewServeMux()
 	registerPublicRoutes(publicMux, config, metrics)
 

--- a/server.go
+++ b/server.go
@@ -57,6 +57,8 @@ func buildHTTPServers(config RuntimeConfig, listenPort int, managementAddress st
 	}
 
 	if managementAddress == "" {
+		// Without a separate management listener, expose health and metrics on
+		// the public listener for backwards-compatible single-port operation.
 		registerInternalRoutes(publicMux, metrics)
 		return servers
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -66,9 +66,9 @@ func TestBuildHTTPServersSeparatesManagementRoutes(t *testing.T) {
 	assertHandlerStatus(t, servers[1].server.Handler, "/calendars/private/feed", http.StatusNotFound)
 }
 
-func testServerConfig() Config {
-	return Config{
-		Calendars: []CalendarConfig{
+func testServerConfig() RuntimeConfig {
+	return RuntimeConfig{
+		Calendars: []Calendar{
 			{
 				Name:  "private",
 				Token: "secret",

--- a/string_rules.go
+++ b/string_rules.go
@@ -25,11 +25,6 @@ func (smr StringMatchRuleConfig) hasConditions() bool {
 		smr.RegexMatch != ""
 }
 
-func (smr StringMatchRuleConfig) validate() error {
-	_, err := smr.compile()
-	return err
-}
-
 func (smr StringMatchRuleConfig) compile() (StringMatchRule, error) {
 	rule := StringMatchRule{
 		Null:     smr.Null,

--- a/string_rules.go
+++ b/string_rules.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 )
 
-// StringMatchRule defines match rules for VEvent properties with string values
+// StringMatchRule is the YAML-backed string match configuration. Regex values
+// are compiled into CompiledStringMatchRule during runtime config preparation.
 type StringMatchRule struct {
 	Null       bool   `yaml:"empty"`
 	Contains   string `yaml:"contains"`
@@ -60,6 +61,8 @@ func (smr StringMatchRule) matchesString(data string) bool {
 	return rule.matchesString(data)
 }
 
+// CompiledStringMatchRule is the runtime string matcher. Regex is compiled once
+// so event processing can match without reparsing configuration.
 type CompiledStringMatchRule struct {
 	Null     bool
 	Contains string

--- a/string_rules.go
+++ b/string_rules.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"regexp"
 	"strings"
 )
@@ -26,49 +25,83 @@ func (smr StringMatchRule) hasConditions() bool {
 }
 
 func (smr StringMatchRule) validate() error {
+	_, err := smr.compile()
+	return err
+}
+
+func (smr StringMatchRule) compile() (CompiledStringMatchRule, error) {
+	rule := CompiledStringMatchRule{
+		Null:     smr.Null,
+		Contains: smr.Contains,
+		Prefix:   smr.Prefix,
+		Suffix:   smr.Suffix,
+	}
+
 	if smr.RegexMatch == "" {
-		return nil
+		return rule, nil
 	}
 
-	if _, err := regexp.Compile(smr.RegexMatch); err != nil {
-		return fmt.Errorf("invalid regex %q: %w", smr.RegexMatch, err)
+	regex, err := regexp.Compile(smr.RegexMatch)
+	if err != nil {
+		return rule, fmt.Errorf("invalid regex %q: %w", smr.RegexMatch, err)
 	}
+	rule.Regex = regex
 
-	return nil
+	return rule, nil
 }
 
 // Returns true if a given string (data) matches ALL StringMatchRule conditions
 func (smr StringMatchRule) matchesString(data string) bool {
+	rule, err := smr.compile()
+	if err != nil {
+		return false
+	}
+
+	return rule.matchesString(data)
+}
+
+type CompiledStringMatchRule struct {
+	Null     bool
+	Contains string
+	Prefix   string
+	Suffix   string
+	Regex    *regexp.Regexp
+}
+
+func (rule CompiledStringMatchRule) hasConditions() bool {
+	return rule.Null ||
+		rule.Contains != "" ||
+		rule.Prefix != "" ||
+		rule.Suffix != "" ||
+		rule.Regex != nil
+}
+
+func (rule CompiledStringMatchRule) matchesString(data string) bool {
 	// check null if set and don't process further - this condition can only be met on its own
-	if smr.Null {
+	if rule.Null {
 		return data == ""
 	}
 	// check contains if set
-	if smr.Contains != "" {
-		if data == "" || !strings.Contains(data, smr.Contains) {
+	if rule.Contains != "" {
+		if data == "" || !strings.Contains(data, rule.Contains) {
 			return false
 		}
 	}
 	// check prefix if set
-	if smr.Prefix != "" {
-		if data == "" || !strings.HasPrefix(data, smr.Prefix) {
+	if rule.Prefix != "" {
+		if data == "" || !strings.HasPrefix(data, rule.Prefix) {
 			return false
 		}
 	}
 	// check suffix if set
-	if smr.Suffix != "" {
-		if data == "" || !strings.HasSuffix(data, smr.Suffix) {
+	if rule.Suffix != "" {
+		if data == "" || !strings.HasSuffix(data, rule.Suffix) {
 			return false
 		}
 	}
 	// check regex match if set
-	if smr.RegexMatch != "" {
-		re, err := regexp.Compile(smr.RegexMatch)
-		if err != nil {
-			slog.Warn("error processing regex rule", "value", smr.RegexMatch)
-			return false // regex error is considered a failure to match
-		}
-		match := re.MatchString(data)
+	if rule.Regex != nil {
+		match := rule.Regex.MatchString(data)
 		if !match {
 			return false // regex didn't match
 		}

--- a/string_rules.go
+++ b/string_rules.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// StringMatchRule is the YAML-backed string match configuration. Regex values
-// are compiled into CompiledStringMatchRule during runtime config preparation.
-type StringMatchRule struct {
+// StringMatchRuleConfig is the YAML-backed string match configuration. Regex values
+// are compiled into StringMatchRule during runtime config preparation.
+type StringMatchRuleConfig struct {
 	Null       bool   `yaml:"empty"`
 	Contains   string `yaml:"contains"`
 	Prefix     string `yaml:"prefix"`
@@ -16,8 +16,8 @@ type StringMatchRule struct {
 	RegexMatch string `yaml:"regex"`
 }
 
-// Returns true if StringMatchRule has any conditions
-func (smr StringMatchRule) hasConditions() bool {
+// Returns true if StringMatchRuleConfig has any conditions
+func (smr StringMatchRuleConfig) hasConditions() bool {
 	return smr.Null ||
 		smr.Contains != "" ||
 		smr.Prefix != "" ||
@@ -25,13 +25,13 @@ func (smr StringMatchRule) hasConditions() bool {
 		smr.RegexMatch != ""
 }
 
-func (smr StringMatchRule) validate() error {
+func (smr StringMatchRuleConfig) validate() error {
 	_, err := smr.compile()
 	return err
 }
 
-func (smr StringMatchRule) compile() (CompiledStringMatchRule, error) {
-	rule := CompiledStringMatchRule{
+func (smr StringMatchRuleConfig) compile() (StringMatchRule, error) {
+	rule := StringMatchRule{
 		Null:     smr.Null,
 		Contains: smr.Contains,
 		Prefix:   smr.Prefix,
@@ -51,8 +51,8 @@ func (smr StringMatchRule) compile() (CompiledStringMatchRule, error) {
 	return rule, nil
 }
 
-// Returns true if a given string (data) matches ALL StringMatchRule conditions
-func (smr StringMatchRule) matchesString(data string) bool {
+// Returns true if a given string (data) matches ALL StringMatchRuleConfig conditions
+func (smr StringMatchRuleConfig) matchesString(data string) bool {
 	rule, err := smr.compile()
 	if err != nil {
 		return false
@@ -61,9 +61,9 @@ func (smr StringMatchRule) matchesString(data string) bool {
 	return rule.matchesString(data)
 }
 
-// CompiledStringMatchRule is the runtime string matcher. Regex is compiled once
+// StringMatchRule is the runtime string matcher. Regex is compiled once
 // so event processing can match without reparsing configuration.
-type CompiledStringMatchRule struct {
+type StringMatchRule struct {
 	Null     bool
 	Contains string
 	Prefix   string
@@ -71,7 +71,7 @@ type CompiledStringMatchRule struct {
 	Regex    *regexp.Regexp
 }
 
-func (rule CompiledStringMatchRule) hasConditions() bool {
+func (rule StringMatchRule) hasConditions() bool {
 	return rule.Null ||
 		rule.Contains != "" ||
 		rule.Prefix != "" ||
@@ -79,7 +79,7 @@ func (rule CompiledStringMatchRule) hasConditions() bool {
 		rule.Regex != nil
 }
 
-func (rule CompiledStringMatchRule) matchesString(data string) bool {
+func (rule StringMatchRule) matchesString(data string) bool {
 	// check null if set and don't process further - this condition can only be met on its own
 	if rule.Null {
 		return data == ""

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -2,40 +2,40 @@ package main
 
 import "testing"
 
-func TestStringMatchRuleHasConditions(t *testing.T) {
+func TestStringMatchRuleConfigHasConditions(t *testing.T) {
 	tests := []struct {
 		name string
-		rule StringMatchRule
+		rule StringMatchRuleConfig
 		want bool
 	}{
 		{
 			name: "empty rule",
-			rule: StringMatchRule{},
+			rule: StringMatchRuleConfig{},
 			want: false,
 		},
 		{
 			name: "empty condition",
-			rule: StringMatchRule{Null: true},
+			rule: StringMatchRuleConfig{Null: true},
 			want: true,
 		},
 		{
 			name: "contains condition",
-			rule: StringMatchRule{Contains: "event"},
+			rule: StringMatchRuleConfig{Contains: "event"},
 			want: true,
 		},
 		{
 			name: "prefix condition",
-			rule: StringMatchRule{Prefix: "event"},
+			rule: StringMatchRuleConfig{Prefix: "event"},
 			want: true,
 		},
 		{
 			name: "suffix condition",
-			rule: StringMatchRule{Suffix: "event"},
+			rule: StringMatchRuleConfig{Suffix: "event"},
 			want: true,
 		},
 		{
 			name: "regex condition",
-			rule: StringMatchRule{RegexMatch: "event"},
+			rule: StringMatchRuleConfig{RegexMatch: "event"},
 			want: true,
 		},
 	}
@@ -50,25 +50,25 @@ func TestStringMatchRuleHasConditions(t *testing.T) {
 	}
 }
 
-func TestStringMatchRuleValidate(t *testing.T) {
+func TestStringMatchRuleConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		rule    StringMatchRule
+		rule    StringMatchRuleConfig
 		wantErr bool
 	}{
 		{
 			name:    "empty rule is valid",
-			rule:    StringMatchRule{},
+			rule:    StringMatchRuleConfig{},
 			wantErr: false,
 		},
 		{
 			name:    "valid regex is valid",
-			rule:    StringMatchRule{RegexMatch: `cal.*event`},
+			rule:    StringMatchRuleConfig{RegexMatch: `cal.*event`},
 			wantErr: false,
 		},
 		{
 			name:    "invalid regex is invalid",
-			rule:    StringMatchRule{RegexMatch: `[`},
+			rule:    StringMatchRuleConfig{RegexMatch: `[`},
 			wantErr: true,
 		},
 	}
@@ -83,8 +83,8 @@ func TestStringMatchRuleValidate(t *testing.T) {
 	}
 }
 
-func TestStringMatchRuleCompile(t *testing.T) {
-	rule, err := (StringMatchRule{
+func TestStringMatchRuleConfigCompile(t *testing.T) {
+	rule, err := (StringMatchRuleConfig{
 		Contains:   "calendar",
 		Prefix:     "team",
 		Suffix:     "event",
@@ -102,107 +102,107 @@ func TestStringMatchRuleCompile(t *testing.T) {
 	}
 }
 
-func TestStringMatchRuleCompileInvalidRegex(t *testing.T) {
-	_, err := (StringMatchRule{RegexMatch: `[`}).compile()
+func TestStringMatchRuleConfigCompileInvalidRegex(t *testing.T) {
+	_, err := (StringMatchRuleConfig{RegexMatch: `[`}).compile()
 	if err == nil {
 		t.Fatal("compile() returned nil error")
 	}
 }
 
-func TestStringMatchRuleMatchesString(t *testing.T) {
+func TestStringMatchRuleConfigMatchesString(t *testing.T) {
 	tests := []struct {
 		name string
-		rule StringMatchRule
+		rule StringMatchRuleConfig
 		data string
 		want bool
 	}{
 		{
 			name: "empty rule matches non-empty string",
-			rule: StringMatchRule{},
+			rule: StringMatchRuleConfig{},
 			data: "calendar event",
 			want: true,
 		},
 		{
 			name: "empty rule matches empty string",
-			rule: StringMatchRule{},
+			rule: StringMatchRuleConfig{},
 			data: "",
 			want: true,
 		},
 		{
 			name: "empty condition matches empty string",
-			rule: StringMatchRule{Null: true},
+			rule: StringMatchRuleConfig{Null: true},
 			data: "",
 			want: true,
 		},
 		{
 			name: "empty condition rejects non-empty string",
-			rule: StringMatchRule{Null: true},
+			rule: StringMatchRuleConfig{Null: true},
 			data: "calendar event",
 			want: false,
 		},
 		{
 			name: "contains matches",
-			rule: StringMatchRule{Contains: "event"},
+			rule: StringMatchRuleConfig{Contains: "event"},
 			data: "calendar event",
 			want: true,
 		},
 		{
 			name: "contains rejects missing value",
-			rule: StringMatchRule{Contains: "shift"},
+			rule: StringMatchRuleConfig{Contains: "shift"},
 			data: "calendar event",
 			want: false,
 		},
 		{
 			name: "contains rejects empty data",
-			rule: StringMatchRule{Contains: "event"},
+			rule: StringMatchRuleConfig{Contains: "event"},
 			data: "",
 			want: false,
 		},
 		{
 			name: "prefix matches",
-			rule: StringMatchRule{Prefix: "calendar"},
+			rule: StringMatchRuleConfig{Prefix: "calendar"},
 			data: "calendar event",
 			want: true,
 		},
 		{
 			name: "prefix rejects missing prefix",
-			rule: StringMatchRule{Prefix: "event"},
+			rule: StringMatchRuleConfig{Prefix: "event"},
 			data: "calendar event",
 			want: false,
 		},
 		{
 			name: "suffix matches",
-			rule: StringMatchRule{Suffix: "event"},
+			rule: StringMatchRuleConfig{Suffix: "event"},
 			data: "calendar event",
 			want: true,
 		},
 		{
 			name: "suffix rejects missing suffix",
-			rule: StringMatchRule{Suffix: "calendar"},
+			rule: StringMatchRuleConfig{Suffix: "calendar"},
 			data: "calendar event",
 			want: false,
 		},
 		{
 			name: "regex matches",
-			rule: StringMatchRule{RegexMatch: `cal.*event`},
+			rule: StringMatchRuleConfig{RegexMatch: `cal.*event`},
 			data: "calendar event",
 			want: true,
 		},
 		{
 			name: "regex rejects missing match",
-			rule: StringMatchRule{RegexMatch: `^event`},
+			rule: StringMatchRuleConfig{RegexMatch: `^event`},
 			data: "calendar event",
 			want: false,
 		},
 		{
 			name: "invalid regex rejects",
-			rule: StringMatchRule{RegexMatch: `[`},
+			rule: StringMatchRuleConfig{RegexMatch: `[`},
 			data: "calendar event",
 			want: false,
 		},
 		{
 			name: "combined conditions all match",
-			rule: StringMatchRule{
+			rule: StringMatchRuleConfig{
 				Contains:   "calendar",
 				Prefix:     "team",
 				Suffix:     "event",
@@ -213,7 +213,7 @@ func TestStringMatchRuleMatchesString(t *testing.T) {
 		},
 		{
 			name: "combined conditions reject partial match",
-			rule: StringMatchRule{
+			rule: StringMatchRuleConfig{
 				Contains:   "calendar",
 				Prefix:     "team",
 				Suffix:     "shift",

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -50,39 +50,6 @@ func TestStringMatchRuleConfigHasConditions(t *testing.T) {
 	}
 }
 
-func TestStringMatchRuleConfigValidate(t *testing.T) {
-	tests := []struct {
-		name    string
-		rule    StringMatchRuleConfig
-		wantErr bool
-	}{
-		{
-			name:    "empty rule is valid",
-			rule:    StringMatchRuleConfig{},
-			wantErr: false,
-		},
-		{
-			name:    "valid regex is valid",
-			rule:    StringMatchRuleConfig{RegexMatch: `cal.*event`},
-			wantErr: false,
-		},
-		{
-			name:    "invalid regex is invalid",
-			rule:    StringMatchRuleConfig{RegexMatch: `[`},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.rule.validate()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
 func TestStringMatchRuleConfigCompile(t *testing.T) {
 	rule, err := (StringMatchRuleConfig{
 		Contains:   "calendar",

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -83,6 +83,32 @@ func TestStringMatchRuleValidate(t *testing.T) {
 	}
 }
 
+func TestStringMatchRuleCompile(t *testing.T) {
+	rule, err := (StringMatchRule{
+		Contains:   "calendar",
+		Prefix:     "team",
+		Suffix:     "event",
+		RegexMatch: `team .* event`,
+	}).compile()
+	if err != nil {
+		t.Fatalf("compile() returned error: %v", err)
+	}
+
+	if !rule.matchesString("team calendar event") {
+		t.Fatal("compiled rule did not match expected value")
+	}
+	if rule.matchesString("team calendar shift") {
+		t.Fatal("compiled rule matched unexpected value")
+	}
+}
+
+func TestStringMatchRuleCompileInvalidRegex(t *testing.T) {
+	_, err := (StringMatchRule{RegexMatch: `[`}).compile()
+	if err == nil {
+		t.Fatal("compile() returned nil error")
+	}
+}
+
 func TestStringMatchRuleMatchesString(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
This PR separates YAML-backed config from runtime state and moves rule compilation into an explicit config compilation step.

- Adds runtime `Calendar` and `RuntimeConfig` types separate from YAML-backed `CalendarConfig` and adds `Config.Compile()` to convert loaded config to `RuntimeConfig`.
- Introduces consistent config/runtime naming:
    - `CalendarConfig` -> `Calendar`
    - `FilterConfig` -> `Filter`
    - `EventMatchRulesConfig` -> `EventMatchRules`
    - `StringMatchRuleConfig` -> `StringMatchRule`
- Compiles regex match rules once during config compilation instead of during event processing.
- Improves invalid regex errors with calendar, filter index, and match property context.
- `LoadConfig` now returns `(Config, error)` instead of mutating a receiver and returning `bool` and config errors are logged in main.