### PR TITLE
Add environment-based configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ The following transformations are available for strings:
 
 You can load `feed_url` and `token` values from files by specifying the `feed_url_file` and `token_file` fields in the calendar configuration. When these fields are set, any values directly provided for `feed_url` or `token` are ignored.
 
+You can also reference environment variables from `feed_url` and `token` by setting the field value to an exact `${ENV_NAME}` reference. Missing or empty environment variables fail config loading. Partial string expansion is not supported, and `feed_url_file` / `token_file` still take precedence.
+
+```yaml
+calendars:
+  - name: private
+    token: "${CALENDAR_TOKEN}"
+    feed_url: "${CALENDAR_FEED_URL}"
+```
+
 For example:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ Liveness and readiness endpoints are exposed at `/liveness` and `/readiness`. By
 
 Prometheus metrics can be enabled with `-metrics`, which exposes `/metrics`. Metrics use aggregate labels by default; `-metrics-calendar-labels` additionally exposes per-calendar metrics labelled by calendar name. If metrics are enabled without `-management-address`, the metrics endpoint is exposed on the main listener and the service logs a warning.
 
+### Environment variables
+
+Most runtime flags can also be set with environment variables. CLI flags take precedence over environment variables.
+
+| Flag | Environment variable | Description |
+| --- | --- | --- |
+| `-config` | `ICAL_FILTER_PROXY_CONFIG` | Path to the YAML config file. |
+| `-address` | `ICAL_FILTER_PROXY_ADDRESS` | Address for the public calendar listener. |
+| `-debug` | `ICAL_FILTER_PROXY_DEBUG` | Enable debug logging. |
+| `-json` | `ICAL_FILTER_PROXY_JSON` | Emit logs as JSON. |
+| `-validate` | `ICAL_FILTER_PROXY_VALIDATE` | Validate config and exit. |
+| `-metrics` | `ICAL_FILTER_PROXY_METRICS` | Enable Prometheus metrics. |
+| `-metrics-calendar-labels` | `ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS` | Enable per-calendar metric labels. |
+| `-management-address` | `ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS` | Address for liveness, readiness, and metrics endpoints. |
+
+`-version` is CLI-only.
+
 ### Filters
 
 Calendar events are filtered using a similar concept to email filtering. A list of filters is defined for each calendar in the config.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ calendars:
 ## Endpoints
 
 The service exposes a simple HTTP API for accessing the proxied calendars.
-The base URL is `http://<host>:<port>/calendars/<calendar_name>/feed`.
+The base URL is `http://<host>:<port>/calendars/<calendar_name>/feed`. The public listener defaults to `:8080` and can be changed with `-address`, for example `-address 127.0.0.1:8080`.
 
 Liveness and readiness endpoints are exposed at `/liveness` and `/readiness`. By default these are served on the main listener with the calendar endpoints. Set `-management-address`, such as `-management-address 127.0.0.1:9090`, to serve liveness, readiness, and metrics on a separate management listener instead.
 

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -18,6 +19,10 @@ type Config struct {
 // calendar-level settings. Rule compilation and regex validation happen when
 // building RuntimeConfig.
 func LoadConfig(file string) (Config, error) {
+	return loadConfig(file, os.LookupEnv)
+}
+
+func loadConfig(file string, lookupEnv envLookupFunc) (Config, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return Config{}, fmt.Errorf("open config file %q: %w; use -config to specify a different file", file, err)
@@ -50,6 +55,11 @@ func LoadConfig(file string) (Config, error) {
 			if err != nil {
 				return Config{}, fmt.Errorf("calendar %q: read feed_url_file %q: %w", calendarConfig.Name, calendarConfig.FeedURLFile, err)
 			}
+		} else {
+			calendarConfig.FeedURL, err = resolveConfigEnvReference(calendarConfig.FeedURL, lookupEnv)
+			if err != nil {
+				return Config{}, fmt.Errorf("calendar %q: feed_url: %w", calendarConfig.Name, err)
+			}
 		}
 
 		// check if url seems valid
@@ -63,6 +73,11 @@ func LoadConfig(file string) (Config, error) {
 			if err != nil {
 				return Config{}, fmt.Errorf("calendar %q: read token_file %q: %w", calendarConfig.Name, calendarConfig.TokenFile, err)
 			}
+		} else {
+			calendarConfig.Token, err = resolveConfigEnvReference(calendarConfig.Token, lookupEnv)
+			if err != nil {
+				return Config{}, fmt.Errorf("calendar %q: token: %w", calendarConfig.Name, err)
+			}
 		}
 
 		if !calendarConfig.Public && calendarConfig.Token == "" {
@@ -72,6 +87,23 @@ func LoadConfig(file string) (Config, error) {
 	}
 
 	return config, nil
+}
+
+var exactEnvReferencePattern = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
+
+func resolveConfigEnvReference(value string, lookupEnv envLookupFunc) (string, error) {
+	matches := exactEnvReferencePattern.FindStringSubmatch(value)
+	if matches == nil {
+		return value, nil
+	}
+
+	envName := matches[1]
+	envValue, ok := lookupEnv(envName)
+	if !ok || envValue == "" {
+		return "", fmt.Errorf("environment variable %s is not set or is empty", envName)
+	}
+
+	return envValue, nil
 }
 
 func readSecretFile(filePath string) (string, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -135,6 +135,112 @@ calendars:
 	}
 }
 
+func TestLoadConfigResolvesEnvironmentReferences(t *testing.T) {
+	configFile := writeTempFile(t, "config-*.yaml", `
+calendars:
+  - name: private
+    token: ${CALENDAR_TOKEN}
+    feed_url: ${CALENDAR_FEED_URL}
+`)
+
+	config, err := loadConfig(configFile, mapEnv(map[string]string{
+		"CALENDAR_TOKEN":    "env-token",
+		"CALENDAR_FEED_URL": "https://example.com/from-env.ics",
+	}))
+	if err != nil {
+		t.Fatalf("LoadConfig() returned error: %v", err)
+	}
+
+	if got := config.Calendars[0].Token; got != "env-token" {
+		t.Fatalf("Token = %q, want env-token", got)
+	}
+	if got := config.Calendars[0].FeedURL; got != "https://example.com/from-env.ics" {
+		t.Fatalf("FeedURL = %q, want https://example.com/from-env.ics", got)
+	}
+}
+
+func TestLoadConfigRejectsMissingEnvironmentReference(t *testing.T) {
+	configFile := writeTempFile(t, "config-*.yaml", `
+calendars:
+  - name: private
+    token: ${MISSING_TOKEN}
+    feed_url: https://example.com/feed.ics
+`)
+
+	_, err := loadConfig(configFile, emptyEnv)
+	if err == nil {
+		t.Fatal("LoadConfig() returned nil error")
+	}
+	if !strings.Contains(err.Error(), "MISSING_TOKEN") {
+		t.Fatalf("LoadConfig() error = %q, want missing env name", err)
+	}
+}
+
+func TestLoadConfigRejectsEmptyEnvironmentReference(t *testing.T) {
+	configFile := writeTempFile(t, "config-*.yaml", `
+calendars:
+  - name: private
+    token: ${EMPTY_TOKEN}
+    feed_url: https://example.com/feed.ics
+`)
+
+	_, err := loadConfig(configFile, mapEnv(map[string]string{
+		"EMPTY_TOKEN": "",
+	}))
+	if err == nil {
+		t.Fatal("LoadConfig() returned nil error")
+	}
+	if !strings.Contains(err.Error(), "EMPTY_TOKEN") {
+		t.Fatalf("LoadConfig() error = %q, want empty env name", err)
+	}
+}
+
+func TestLoadConfigDoesNotExpandPartialEnvironmentReferences(t *testing.T) {
+	configFile := writeTempFile(t, "config-*.yaml", `
+calendars:
+  - name: private
+    token: ${TOKEN}
+    feed_url: https://example.com/${CALENDAR_TOKEN}/feed.ics
+`)
+
+	config, err := loadConfig(configFile, mapEnv(map[string]string{
+		"TOKEN":          "env-token",
+		"CALENDAR_TOKEN": "secret-path",
+	}))
+	if err != nil {
+		t.Fatalf("LoadConfig() returned error: %v", err)
+	}
+
+	if got := config.Calendars[0].FeedURL; got != "https://example.com/${CALENDAR_TOKEN}/feed.ics" {
+		t.Fatalf("FeedURL = %q, want literal partial env reference", got)
+	}
+}
+
+func TestLoadConfigSecretFilesTakePrecedenceOverEnvironmentReferences(t *testing.T) {
+	tokenFile := writeTempFile(t, "token-*", "file-token\n")
+	feedURLFile := writeTempFile(t, "feed-url-*", "https://example.com/from-file.ics\n")
+	configFile := writeTempFile(t, "config-*.yaml", `
+calendars:
+  - name: private
+    token: ${CALENDAR_TOKEN}
+    token_file: `+tokenFile+`
+    feed_url: ${CALENDAR_FEED_URL}
+    feed_url_file: `+feedURLFile+`
+`)
+
+	config, err := loadConfig(configFile, emptyEnv)
+	if err != nil {
+		t.Fatalf("LoadConfig() returned error: %v", err)
+	}
+
+	if got := config.Calendars[0].Token; got != "file-token" {
+		t.Fatalf("Token = %q, want file-token", got)
+	}
+	if got := config.Calendars[0].FeedURL; got != "https://example.com/from-file.ics" {
+		t.Fatalf("FeedURL = %q, want https://example.com/from-file.ics", got)
+	}
+}
+
 func TestConfigCompile(t *testing.T) {
 	config := Config{
 		Calendars: []CalendarConfig{

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func main() {
 		configFile             string
 		debugLogging           bool
 		jsonLogging            bool
-		listenPort             int
+		address                string
 		validateConfig         bool
 		printVersion           bool
 		metricsEnabled         bool
@@ -25,7 +25,7 @@ func main() {
 	flag.BoolVar(&debugLogging, "debug", false, "enable debug logging")
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
 	flag.BoolVar(&jsonLogging, "json", false, "output logging in JSON format")
-	flag.IntVar(&listenPort, "port", 8080, "listening port for api")
+	flag.StringVar(&address, "address", ":8080", "address for calendar API listener")
 	flag.BoolVar(&validateConfig, "validate", false, "validate config and exit")
 	flag.BoolVar(&metricsEnabled, "metrics", false, "enable prometheus metrics endpoint")
 	flag.BoolVar(&calendarMetricsEnabled, "metrics-calendar-labels", false, "enable per-calendar prometheus metrics")
@@ -91,7 +91,7 @@ func main() {
 		slog.Warn("Prometheus metrics endpoint enabled on public listener; set -management-address to expose management endpoints separately")
 	}
 
-	servers := buildHTTPServers(runtimeConfig, listenPort, managementAddress, metrics)
+	servers := buildHTTPServers(runtimeConfig, address, managementAddress, metrics)
 	if err := runHTTPServers(servers...); err != nil {
 		slog.Error("Error running web server", "error", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -1,39 +1,20 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 )
 
 func main() {
-
-	// command-line args
-	var (
-		configFile             string
-		debugLogging           bool
-		jsonLogging            bool
-		address                string
-		validateConfig         bool
-		printVersion           bool
-		metricsEnabled         bool
-		calendarMetricsEnabled bool
-		managementAddress      string
-	)
-	flag.StringVar(&configFile, "config", "config.yaml", "config file")
-	flag.BoolVar(&debugLogging, "debug", false, "enable debug logging")
-	flag.BoolVar(&printVersion, "version", false, "print version and exit")
-	flag.BoolVar(&jsonLogging, "json", false, "output logging in JSON format")
-	flag.StringVar(&address, "address", ":8080", "address for calendar API listener")
-	flag.BoolVar(&validateConfig, "validate", false, "validate config and exit")
-	flag.BoolVar(&metricsEnabled, "metrics", false, "enable prometheus metrics endpoint")
-	flag.BoolVar(&calendarMetricsEnabled, "metrics-calendar-labels", false, "enable per-calendar prometheus metrics")
-	flag.StringVar(&managementAddress, "management-address", "", "optional address for liveness, readiness, and metrics endpoints")
-	flag.Parse()
+	options, err := parseOptions(os.Args[1:], os.LookupEnv)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	// print version and exit
-	if printVersion {
+	if options.printVersion {
 		build := currentBuildInfo()
 		fmt.Println("version:", build.Version)
 		fmt.Println("revision:", build.Revision)
@@ -43,7 +24,7 @@ func main() {
 
 	// setup logging options
 	loggingLevel := slog.LevelInfo // default loglevel
-	if debugLogging {
+	if options.debugLogging {
 		loggingLevel = slog.LevelDebug // debug logging enabled
 	}
 	opts := &slog.HandlerOptions{
@@ -52,7 +33,7 @@ func main() {
 
 	// create json or text logger based on args
 	var logger *slog.Logger
-	if jsonLogging {
+	if options.jsonLogging {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, opts))
 	} else {
 		logger = slog.New(slog.NewTextHandler(os.Stdout, opts))
@@ -60,8 +41,8 @@ func main() {
 	slog.SetDefault(logger)
 
 	// load configuration
-	slog.Debug("reading config", "configFile", configFile)
-	config, err := LoadConfig(configFile)
+	slog.Debug("reading config", "configFile", options.configFile)
+	config, err := LoadConfig(options.configFile)
 	if err != nil {
 		slog.Error("Invalid configuration", "error", err)
 		os.Exit(1) // fail if config is not valid
@@ -77,21 +58,21 @@ func main() {
 	}
 
 	// print a message and exit if validate arg was specified
-	if validateConfig {
+	if options.validateConfig {
 		slog.Info("configuration was validated successfully")
 		os.Exit(0)
 	}
 
 	var metrics *prometheusMetrics
-	if metricsEnabled {
-		metrics = newPrometheusMetrics(calendarMetricsEnabled)
+	if options.metricsEnabled {
+		metrics = newPrometheusMetrics(options.calendarMetricsEnabled)
 	}
 
-	if metricsEnabled && managementAddress == "" {
+	if options.metricsEnabled && options.managementAddress == "" {
 		slog.Warn("Prometheus metrics endpoint enabled on public listener; set -management-address to expose management endpoints separately")
 	}
 
-	servers := buildHTTPServers(runtimeConfig, address, managementAddress, metrics)
+	servers := buildHTTPServers(runtimeConfig, options.address, options.managementAddress, metrics)
 	if err := runHTTPServers(servers...); err != nil {
 		slog.Error("Error running web server", "error", err)
 		os.Exit(1)

--- a/options.go
+++ b/options.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+const (
+	envConfig                = "ICAL_FILTER_PROXY_CONFIG"
+	envAddress               = "ICAL_FILTER_PROXY_ADDRESS"
+	envDebug                 = "ICAL_FILTER_PROXY_DEBUG"
+	envJSON                  = "ICAL_FILTER_PROXY_JSON"
+	envValidate              = "ICAL_FILTER_PROXY_VALIDATE"
+	envMetrics               = "ICAL_FILTER_PROXY_METRICS"
+	envMetricsCalendarLabels = "ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS"
+	envManagementAddress     = "ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS"
+)
+
+type appOptions struct {
+	configFile             string
+	debugLogging           bool
+	jsonLogging            bool
+	address                string
+	validateConfig         bool
+	printVersion           bool
+	metricsEnabled         bool
+	calendarMetricsEnabled bool
+	managementAddress      string
+}
+
+type envLookupFunc func(string) (string, bool)
+
+func parseOptions(args []string, lookupEnv envLookupFunc) (appOptions, error) {
+	options, err := defaultOptionsFromEnv(lookupEnv)
+	if err != nil {
+		return appOptions{}, err
+	}
+
+	flags := flag.NewFlagSet("ical-filter-proxy", flag.ContinueOnError)
+	flags.StringVar(&options.configFile, "config", options.configFile, "config file")
+	flags.BoolVar(&options.debugLogging, "debug", options.debugLogging, "enable debug logging")
+	flags.BoolVar(&options.printVersion, "version", false, "print version and exit")
+	flags.BoolVar(&options.jsonLogging, "json", options.jsonLogging, "output logging in JSON format")
+	flags.StringVar(&options.address, "address", options.address, "address for calendar API listener")
+	flags.BoolVar(&options.validateConfig, "validate", options.validateConfig, "validate config and exit")
+	flags.BoolVar(&options.metricsEnabled, "metrics", options.metricsEnabled, "enable prometheus metrics endpoint")
+	flags.BoolVar(&options.calendarMetricsEnabled, "metrics-calendar-labels", options.calendarMetricsEnabled, "enable per-calendar prometheus metrics")
+	flags.StringVar(&options.managementAddress, "management-address", options.managementAddress, "optional address for liveness, readiness, and metrics endpoints")
+
+	if err := flags.Parse(args); err != nil {
+		return appOptions{}, err
+	}
+
+	return options, nil
+}
+
+func defaultOptionsFromEnv(lookupEnv envLookupFunc) (appOptions, error) {
+	options := appOptions{
+		configFile: "config.yaml",
+		address:    ":8080",
+	}
+
+	options.configFile = envString(lookupEnv, envConfig, options.configFile)
+	options.address = envString(lookupEnv, envAddress, options.address)
+	options.managementAddress = envString(lookupEnv, envManagementAddress, options.managementAddress)
+
+	var err error
+	if options.debugLogging, err = envBool(lookupEnv, envDebug, options.debugLogging); err != nil {
+		return appOptions{}, err
+	}
+	if options.jsonLogging, err = envBool(lookupEnv, envJSON, options.jsonLogging); err != nil {
+		return appOptions{}, err
+	}
+	if options.validateConfig, err = envBool(lookupEnv, envValidate, options.validateConfig); err != nil {
+		return appOptions{}, err
+	}
+	if options.metricsEnabled, err = envBool(lookupEnv, envMetrics, options.metricsEnabled); err != nil {
+		return appOptions{}, err
+	}
+	if options.calendarMetricsEnabled, err = envBool(lookupEnv, envMetricsCalendarLabels, options.calendarMetricsEnabled); err != nil {
+		return appOptions{}, err
+	}
+
+	return options, nil
+}
+
+func envString(lookupEnv envLookupFunc, name string, fallback string) string {
+	value, ok := lookupEnv(name)
+	if !ok {
+		return fallback
+	}
+
+	return value
+}
+
+func envBool(lookupEnv envLookupFunc, name string, fallback bool) (bool, error) {
+	value, ok := lookupEnv(name)
+	if !ok {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("%s must be a boolean: %w", name, err)
+	}
+
+	return parsed, nil
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseOptionsDefaults(t *testing.T) {
+	options, err := parseOptions(nil, emptyEnv)
+	if err != nil {
+		t.Fatalf("parseOptions() returned error: %v", err)
+	}
+
+	if options.configFile != "config.yaml" {
+		t.Fatalf("configFile = %q, want config.yaml", options.configFile)
+	}
+	if options.address != ":8080" {
+		t.Fatalf("address = %q, want :8080", options.address)
+	}
+	if options.debugLogging {
+		t.Fatal("debugLogging = true, want false")
+	}
+	if options.printVersion {
+		t.Fatal("printVersion = true, want false")
+	}
+}
+
+func TestParseOptionsUsesEnvironmentDefaults(t *testing.T) {
+	env := map[string]string{
+		envConfig:                "/etc/ical-filter-proxy/config.yaml",
+		envAddress:               "127.0.0.1:8081",
+		envDebug:                 "true",
+		envJSON:                  "true",
+		envValidate:              "true",
+		envMetrics:               "true",
+		envMetricsCalendarLabels: "true",
+		envManagementAddress:     "127.0.0.1:9090",
+	}
+
+	options, err := parseOptions(nil, mapEnv(env))
+	if err != nil {
+		t.Fatalf("parseOptions() returned error: %v", err)
+	}
+
+	if options.configFile != "/etc/ical-filter-proxy/config.yaml" {
+		t.Fatalf("configFile = %q, want env value", options.configFile)
+	}
+	if options.address != "127.0.0.1:8081" {
+		t.Fatalf("address = %q, want env value", options.address)
+	}
+	if options.managementAddress != "127.0.0.1:9090" {
+		t.Fatalf("managementAddress = %q, want env value", options.managementAddress)
+	}
+	if !options.debugLogging || !options.jsonLogging || !options.validateConfig || !options.metricsEnabled || !options.calendarMetricsEnabled {
+		t.Fatalf("boolean options = %+v, want all env booleans true", options)
+	}
+}
+
+func TestParseOptionsCLIOverridesEnvironment(t *testing.T) {
+	env := map[string]string{
+		envConfig:            "/etc/config.yaml",
+		envAddress:           ":8081",
+		envDebug:             "true",
+		envMetrics:           "true",
+		envManagementAddress: "127.0.0.1:9090",
+	}
+
+	options, err := parseOptions([]string{
+		"-config", "/tmp/config.yaml",
+		"-address", ":8082",
+		"-debug=false",
+		"-metrics=false",
+		"-management-address", "127.0.0.1:9091",
+	}, mapEnv(env))
+	if err != nil {
+		t.Fatalf("parseOptions() returned error: %v", err)
+	}
+
+	if options.configFile != "/tmp/config.yaml" {
+		t.Fatalf("configFile = %q, want CLI value", options.configFile)
+	}
+	if options.address != ":8082" {
+		t.Fatalf("address = %q, want CLI value", options.address)
+	}
+	if options.debugLogging {
+		t.Fatal("debugLogging = true, want CLI false")
+	}
+	if options.metricsEnabled {
+		t.Fatal("metricsEnabled = true, want CLI false")
+	}
+	if options.managementAddress != "127.0.0.1:9091" {
+		t.Fatalf("managementAddress = %q, want CLI value", options.managementAddress)
+	}
+}
+
+func TestParseOptionsRejectsInvalidBoolEnvironment(t *testing.T) {
+	_, err := parseOptions(nil, mapEnv(map[string]string{
+		envDebug: "sometimes",
+	}))
+	if err == nil {
+		t.Fatal("parseOptions() returned nil error")
+	}
+	if !strings.Contains(err.Error(), envDebug) {
+		t.Fatalf("parseOptions() error = %q, want env var name", err)
+	}
+}
+
+func TestParseOptionsVersionIsCLIOnly(t *testing.T) {
+	options, err := parseOptions(nil, mapEnv(map[string]string{
+		"ICAL_FILTER_PROXY_VERSION": "true",
+	}))
+	if err != nil {
+		t.Fatalf("parseOptions() returned error: %v", err)
+	}
+	if options.printVersion {
+		t.Fatal("printVersion = true from environment, want false")
+	}
+
+	options, err = parseOptions([]string{"-version"}, emptyEnv)
+	if err != nil {
+		t.Fatalf("parseOptions() returned error: %v", err)
+	}
+	if !options.printVersion {
+		t.Fatal("printVersion = false, want CLI true")
+	}
+}
+
+func emptyEnv(string) (string, bool) {
+	return "", false
+}
+
+func mapEnv(values map[string]string) envLookupFunc {
+	return func(name string) (string, bool) {
+		value, ok := values[name]
+		return value, ok
+	}
+}

--- a/server.go
+++ b/server.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 )
@@ -45,14 +44,14 @@ func buildHTTPHandler(listener string, handler http.Handler, metrics *prometheus
 	return requestLoggingMiddleware(handler)
 }
 
-func buildHTTPServers(config RuntimeConfig, listenPort int, managementAddress string, metrics *prometheusMetrics) []managedHTTPServer {
+func buildHTTPServers(config RuntimeConfig, address string, managementAddress string, metrics *prometheusMetrics) []managedHTTPServer {
 	publicMux := http.NewServeMux()
 	registerPublicRoutes(publicMux, config, metrics)
 
 	servers := []managedHTTPServer{
 		{
 			name:   "public",
-			server: newHTTPServer(":"+strconv.Itoa(listenPort), buildHTTPHandler("public", publicMux, metrics)),
+			server: newHTTPServer(address, buildHTTPHandler("public", publicMux, metrics)),
 		},
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -28,7 +28,7 @@ func TestNewHTTPServerSetsTimeouts(t *testing.T) {
 }
 
 func TestBuildHTTPServersRegistersInternalRoutesOnPublicServerByDefault(t *testing.T) {
-	servers := buildHTTPServers(testServerConfig(), 8080, "", nil)
+	servers := buildHTTPServers(testServerConfig(), ":8080", "", nil)
 
 	if len(servers) != 1 {
 		t.Fatalf("server count = %d, want 1", len(servers))
@@ -45,7 +45,7 @@ func TestBuildHTTPServersRegistersInternalRoutesOnPublicServerByDefault(t *testi
 }
 
 func TestBuildHTTPServersSeparatesManagementRoutes(t *testing.T) {
-	servers := buildHTTPServers(testServerConfig(), 8080, "127.0.0.1:9090", nil)
+	servers := buildHTTPServers(testServerConfig(), ":8080", "127.0.0.1:9090", nil)
 
 	if len(servers) != 2 {
 		t.Fatalf("server count = %d, want 2", len(servers))

--- a/service.nix
+++ b/service.nix
@@ -34,10 +34,17 @@ in {
       description = "Group under which ical-filter-proxy runs.";
     };
 
+    address = mkOption {
+      type = types.str;
+      default = ":8080";
+      example = "127.0.0.1:8080";
+      description = "Address on which the public calendar API listener listens.";
+    };
+
     port = mkOption {
       type = types.port;
       default = 8080;
-      description = "Port on which the service listens.";
+      description = "Port to open when openFirewall is enabled.";
     };
 
     managementAddress = mkOption {
@@ -477,8 +484,8 @@ in {
               "${cfg.package}/bin/ical-filter-proxy"
               "-config"
               "${configFile}"
-              "-port"
-              "${toString cfg.port}"
+              "-address"
+              cfg.address
             ]
             ++ optionals (cfg.managementAddress != null) [
               "-management-address"


### PR DESCRIPTION
This PR adds environment variable support for runtime options and selected config fields. Closes #33.

- breaking: Replace `-port` with `-address` for the public listener (default remains `:8080`).
- add env var support for all runtime config flags:
  - `ICAL_FILTER_PROXY_CONFIG`
  - `ICAL_FILTER_PROXY_ADDRESS`
  - `ICAL_FILTER_PROXY_DEBUG`
  - `ICAL_FILTER_PROXY_JSON`
  - `ICAL_FILTER_PROXY_VALIDATE`
  - `ICAL_FILTER_PROXY_METRICS`
  - `ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS`
  - `ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS`
- add config file env substitution for `token` and `feed_url` values:
  - missing or empty referenced env vars fail config load
  - partial string expansion is intentionally not supported
- update nix service module to use `-address`
