### PR TITLE
logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,18 +174,20 @@ Prometheus metrics can be enabled with `-metrics`, which exposes `/metrics`. Met
 
 Most runtime flags can also be set with environment variables. CLI flags take precedence over environment variables.
 
-| Flag | Environment variable | Description |
-| --- | --- | --- |
-| `-config` | `ICAL_FILTER_PROXY_CONFIG` | Path to the YAML config file. |
-| `-address` | `ICAL_FILTER_PROXY_ADDRESS` | Address for the public calendar listener. |
-| `-debug` | `ICAL_FILTER_PROXY_DEBUG` | Enable debug logging. |
-| `-json` | `ICAL_FILTER_PROXY_JSON` | Emit logs as JSON. |
-| `-validate` | `ICAL_FILTER_PROXY_VALIDATE` | Validate config and exit. |
-| `-metrics` | `ICAL_FILTER_PROXY_METRICS` | Enable Prometheus metrics. |
-| `-metrics-calendar-labels` | `ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS` | Enable per-calendar metric labels. |
-| `-management-address` | `ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS` | Address for liveness, readiness, and metrics endpoints. |
+| Flag                       | Environment variable                        | Description                                             |
+| -------------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `-config`                  | `ICAL_FILTER_PROXY_CONFIG`                  | Path to the YAML config file.                           |
+| `-address`                 | `ICAL_FILTER_PROXY_ADDRESS`                 | Address for the public calendar listener.               |
+| `-debug`                   | `ICAL_FILTER_PROXY_DEBUG`                   | Enable debug logging.                                   |
+| `-json`                    | `ICAL_FILTER_PROXY_JSON`                    | Emit logs as JSON.                                      |
+| `-validate`                | `ICAL_FILTER_PROXY_VALIDATE`                | Validate config and exit.                               |
+| `-metrics`                 | `ICAL_FILTER_PROXY_METRICS`                 | Enable Prometheus metrics.                              |
+| `-metrics-calendar-labels` | `ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS` | Enable per-calendar metric labels.                      |
+| `-management-address`      | `ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS`      | Address for liveness, readiness, and metrics endpoints. |
 
 `-version` is CLI-only.
+
+Debug logging includes calendar names, request paths, event summaries, and filter descriptions for debugging filter logic. Avoid enabling `-debug` in environments where logs are broadly accessible or retained longer than necessary.
 
 ### Filters
 

--- a/calendar.go
+++ b/calendar.go
@@ -72,7 +72,7 @@ func (config Config) Compile() (RuntimeConfig, error) {
 func (calendar Calendar) fetch(ctx context.Context) ([]byte, error) {
 
 	// get the iCal feed
-	slog.Debug("Fetching iCal feed", "url", redactURL(calendar.FeedURL))
+	slog.Debug("fetching upstream calendar", "calendar", calendar.Name, "url", redactURL(calendar.FeedURL))
 	feedData, err := fetchUpstreamCalendar(ctx, calendar.FeedURL)
 	if err != nil {
 		return nil, err
@@ -90,15 +90,15 @@ func (calendar Calendar) fetch(ctx context.Context) ([]byte, error) {
 
 	// process filters
 	if len(calendar.Filters) > 0 {
-		slog.Debug("Processing filters", "calendar", calendar.Name)
+		slog.Debug("processing filters", "calendar", calendar.Name)
 		for _, event := range cal.Events() {
 			if !calendar.ProcessEvent(event) {
 				cal.RemoveEvent(event.Id())
 			}
 		}
-		slog.Debug("Filter processing completed", "calendar", calendar.Name)
+		slog.Debug("filter processing completed", "calendar", calendar.Name)
 	} else {
-		slog.Debug("No filters to evaluate", "calendar", calendar.Name)
+		slog.Debug("no filters to evaluate", "calendar", calendar.Name)
 	}
 
 	// serialize output
@@ -129,11 +129,11 @@ func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 
 		// Does the filter match the event?
 		if filter.matchesEvent(*event) {
-			slog.Debug("Filter match found", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+			slog.Debug("filter match found", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
 
 			// The event should get dropped if RemoveEvent is set
 			if filter.RemoveEvent {
-				slog.Debug("Event to be removed, no more rules will be processed", "action", "DELETE", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+				slog.Debug("event removed; stopping rule processing", "action", "delete", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
 				return false
 			}
 
@@ -142,14 +142,14 @@ func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 
 			// Check if we should stop processing rules
 			if filter.Stop {
-				slog.Debug("Stop option is set, no more rules will be processed", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+				slog.Debug("filter stop set; stopping rule processing", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
 				return true
 			}
 		}
 	}
 
 	// Keep event by default if all Filter rules are processed
-	slog.Debug("Rule processing complete, event will be kept", "rule_id", nil, "event_summary", summary.Value)
+	slog.Debug("rule processing complete; keeping event", "rule_id", nil, "event_summary", summary.Value)
 	return true
 
 }

--- a/calendar.go
+++ b/calendar.go
@@ -128,12 +128,12 @@ func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 	for id, filter := range calendar.Filters {
 
 		// Does the filter match the event?
-		if filter.matchesEvent(*event) {
-			slog.Debug("filter match found", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+		if filter.matchesEvent(*event, calendar.Name) {
+			slog.Debug("filter match found", "calendar", calendar.Name, "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
 
 			// The event should get dropped if RemoveEvent is set
 			if filter.RemoveEvent {
-				slog.Debug("event removed; stopping rule processing", "action", "delete", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+				slog.Debug("event removed; stopping rule processing", "calendar", calendar.Name, "action", "delete", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
 				return false
 			}
 
@@ -142,14 +142,14 @@ func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 
 			// Check if we should stop processing rules
 			if filter.Stop {
-				slog.Debug("filter stop set; stopping rule processing", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+				slog.Debug("filter stop set; stopping rule processing", "calendar", calendar.Name, "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
 				return true
 			}
 		}
 	}
 
 	// Keep event by default if all Filter rules are processed
-	slog.Debug("rule processing complete; keeping event", "rule_id", nil, "event_summary", summary.Value)
+	slog.Debug("rule processing complete; keeping event", "calendar", calendar.Name, "rule_id", nil, "event_summary", summary.Value)
 	return true
 
 }

--- a/calendar.go
+++ b/calendar.go
@@ -129,11 +129,11 @@ func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 
 		// Does the filter match the event?
 		if filter.matchesEvent(*event, calendar.Name) {
-			slog.Debug("filter match found", "calendar", calendar.Name, "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+			slog.Debug("filter match found", "calendar", calendar.Name, "filter_index", id, "filter_description", filter.Description, "event_summary", summary.Value)
 
 			// The event should get dropped if RemoveEvent is set
 			if filter.RemoveEvent {
-				slog.Debug("event removed; stopping rule processing", "calendar", calendar.Name, "action", "delete", "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+				slog.Debug("event removed; stopping rule processing", "calendar", calendar.Name, "action", "delete", "filter_index", id, "filter_description", filter.Description, "event_summary", summary.Value)
 				return false
 			}
 
@@ -142,14 +142,14 @@ func (calendar Calendar) ProcessEvent(event *ics.VEvent) bool {
 
 			// Check if we should stop processing rules
 			if filter.Stop {
-				slog.Debug("filter stop set; stopping rule processing", "calendar", calendar.Name, "rule_id", id, "filter_description", filter.Description, "event_summary", summary.Value)
+				slog.Debug("filter stop set; stopping rule processing", "calendar", calendar.Name, "filter_index", id, "filter_description", filter.Description, "event_summary", summary.Value)
 				return true
 			}
 		}
 	}
 
 	// Keep event by default if all Filter rules are processed
-	slog.Debug("rule processing complete; keeping event", "calendar", calendar.Name, "rule_id", nil, "event_summary", summary.Value)
+	slog.Debug("rule processing complete; keeping event", "calendar", calendar.Name, "filter_index", nil, "event_summary", summary.Value)
 	return true
 
 }

--- a/filter.go
+++ b/filter.go
@@ -51,7 +51,7 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 	// Get event Summary - only used for debug logging
 	eventSummary := event.GetProperty(ics.ComponentPropertySummary)
 	if eventSummary == nil {
-		slog.Warn("Unable to process event summary. Event will be dropped")
+		slog.Debug("event missing summary; dropping event")
 		return false // never match if VEvent has no summary
 	}
 
@@ -63,13 +63,13 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 	}
 	for _, match := range stringMatches {
 		if !eventStringPropertyMatches(event, match.property, match.rule) {
-			slog.Debug("Event property does not match filter conditions", "property", match.name, "event_summary", eventSummary.Value, "filter", filter.Description)
+			slog.Debug("event property does not match filter conditions", "property", match.name, "event_summary", eventSummary.Value, "filter", filter.Description)
 			return false
 		}
 	}
 
 	// VEvent must match if we get here
-	slog.Debug("Event matches filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
+	slog.Debug("event matches filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
 	return true
 }
 

--- a/filter.go
+++ b/filter.go
@@ -44,14 +44,14 @@ func (filter FilterConfig) compile() (Filter, error) {
 }
 
 // Returns true if a VEvent matches the Filter conditions
-func (filter Filter) matchesEvent(event ics.VEvent) bool {
+func (filter Filter) matchesEvent(event ics.VEvent, calendarName string) bool {
 
 	// If an event property is not defined golang-ical returns a nil pointer
 
 	// Get event Summary - only used for debug logging
 	eventSummary := event.GetProperty(ics.ComponentPropertySummary)
 	if eventSummary == nil {
-		slog.Debug("event missing summary; dropping event")
+		slog.Debug("event missing summary; dropping event", "calendar", calendarName)
 		return false // never match if VEvent has no summary
 	}
 
@@ -63,13 +63,13 @@ func (filter Filter) matchesEvent(event ics.VEvent) bool {
 	}
 	for _, match := range stringMatches {
 		if !eventStringPropertyMatches(event, match.property, match.rule) {
-			slog.Debug("event property does not match filter conditions", "property", match.name, "event_summary", eventSummary.Value, "filter", filter.Description)
+			slog.Debug("event property does not match filter conditions", "calendar", calendarName, "property", match.name, "event_summary", eventSummary.Value, "filter_description", filter.Description)
 			return false
 		}
 	}
 
 	// VEvent must match if we get here
-	slog.Debug("event matches filter conditions", "event_summary", eventSummary.Value, "filter", filter.Description)
+	slog.Debug("event matches filter conditions", "calendar", calendarName, "event_summary", eventSummary.Value, "filter_description", filter.Description)
 	return true
 }
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -130,7 +130,7 @@ func TestFilterMatchesEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filter := mustCompileFilter(t, FilterConfig{Match: tt.match})
-			got := filter.matchesEvent(*tt.event)
+			got := filter.matchesEvent(*tt.event, "test")
 			if got != tt.want {
 				t.Fatalf("matchesEvent() = %v, want %v", got, tt.want)
 			}

--- a/handler.go
+++ b/handler.go
@@ -26,7 +26,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		}
 
 		if !calendar.Public && !tokenMatches(r.URL.Query().Get("token"), calendar.Token) {
-			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "client_addr", r.RemoteAddr)
+			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -34,7 +34,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		// fetch and filter upstream calendar
 		feed, err := fetch(r.Context())
 		if err != nil {
-			slog.Error("calendar feed request failed", "calendar", calendar.Name, "error", err)
+			slog.Error("calendar feed request failed", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", r.RemoteAddr, "error", err)
 			http.Error(w, "Bad Gateway", http.StatusBadGateway)
 			return
 		}
@@ -47,7 +47,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 
 		_, err = w.Write(feed)
 		if err != nil {
-			slog.Error("calendar feed response write failed", "calendar", calendar.Name, "error", err)
+			slog.Error("calendar feed response write failed", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", r.RemoteAddr, "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}

--- a/handler.go
+++ b/handler.go
@@ -26,7 +26,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		}
 
 		if !calendar.Public && !tokenMatches(r.URL.Query().Get("token"), calendar.Token) {
-			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "client_ip", r.RemoteAddr)
+			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "client_addr", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/handler.go
+++ b/handler.go
@@ -26,7 +26,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		}
 
 		if !calendar.Public && !tokenMatches(r.URL.Query().Get("token"), calendar.Token) {
-			slog.Warn("Unauthorized access attempt", "client_ip", r.RemoteAddr)
+			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "client_ip", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -34,7 +34,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		// fetch and filter upstream calendar
 		feed, err := fetch(r.Context())
 		if err != nil {
-			slog.Error("Error fetching and filtering feed", "error", err)
+			slog.Error("calendar feed request failed", "calendar", calendar.Name, "error", err)
 			http.Error(w, "Bad Gateway", http.StatusBadGateway)
 			return
 		}
@@ -47,7 +47,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 
 		_, err = w.Write(feed)
 		if err != nil {
-			slog.Error("Error writing response", "error", err)
+			slog.Error("calendar feed response write failed", "calendar", calendar.Name, "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -41,10 +41,10 @@ func main() {
 	slog.SetDefault(logger)
 
 	// load configuration
-	slog.Debug("reading config", "configFile", options.configFile)
+	slog.Debug("reading config", "config_file", options.configFile)
 	config, err := LoadConfig(options.configFile)
 	if err != nil {
-		slog.Error("Invalid configuration", "error", err)
+		slog.Error("invalid configuration", "error", err)
 		os.Exit(1) // fail if config is not valid
 	}
 	slog.Debug("loaded config")
@@ -53,7 +53,7 @@ func main() {
 
 	runtimeConfig, err := config.Compile()
 	if err != nil {
-		slog.Error("Invalid configuration", "error", err)
+		slog.Error("invalid configuration", "error", err)
 		os.Exit(1)
 	}
 
@@ -74,7 +74,7 @@ func main() {
 
 	servers := buildHTTPServers(runtimeConfig, options.address, options.managementAddress, metrics)
 	if err := runHTTPServers(servers...); err != nil {
-		slog.Error("Error running web server", "error", err)
+		slog.Error("web server failed", "error", err)
 		os.Exit(1)
 	}
 
@@ -83,10 +83,10 @@ func main() {
 func logConfigWarnings(config Config) {
 	for _, calendar := range config.Calendars {
 		if calendar.Public {
-			slog.Warn("Calendar has no token set. Authentication will be disabled", "calendar", calendar.Name)
+			slog.Warn("calendar has no token set; authentication disabled", "calendar", calendar.Name)
 		}
 		if len(calendar.Filters) == 0 {
-			slog.Warn("Calendar has no filters and will be proxy-only", "calendar", calendar.Name)
+			slog.Info("calendar has no filters; proxy-only mode enabled", "calendar", calendar.Name)
 		}
 	}
 }

--- a/middleware.go
+++ b/middleware.go
@@ -44,7 +44,7 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 		}
 
 		slog.Info(
-			"HTTP request processed",
+			"http request processed",
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", statusCode,
@@ -60,7 +60,7 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				slog.Error(
-					"Recovered panic while processing HTTP request",
+					"recovered panic while processing http request",
 					"panic", fmt.Sprint(recovered),
 					"path", r.URL.Path,
 					"client_ip", r.RemoteAddr,

--- a/middleware.go
+++ b/middleware.go
@@ -43,15 +43,19 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 			statusCode = http.StatusOK
 		}
 
-		slog.Info(
-			"http request processed",
+		logArgs := []any{
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", statusCode,
 			"duration_ms", time.Since(startedAt).Milliseconds(),
 			"client_addr", r.RemoteAddr,
 			"user_agent", r.UserAgent(),
-		)
+		}
+		if calendarName, ok := calendarNameFromPath(r.URL.Path); ok {
+			logArgs = append(logArgs, "calendar", calendarName)
+		}
+
+		slog.Info("http request processed", logArgs...)
 	})
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -49,7 +49,7 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 			"path", r.URL.Path,
 			"status", statusCode,
 			"duration_ms", time.Since(startedAt).Milliseconds(),
-			"client_ip", r.RemoteAddr,
+			"client_addr", r.RemoteAddr,
 			"user_agent", r.UserAgent(),
 		)
 	})
@@ -63,7 +63,7 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 					"recovered panic while processing http request",
 					"panic", fmt.Sprint(recovered),
 					"path", r.URL.Path,
-					"client_ip", r.RemoteAddr,
+					"client_addr", r.RemoteAddr,
 					"stack", string(debug.Stack()),
 				)
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/middleware.go
+++ b/middleware.go
@@ -63,13 +63,18 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				slog.Error(
-					"recovered panic while processing http request",
+				logArgs := []any{
 					"panic", fmt.Sprint(recovered),
+					"method", r.Method,
 					"path", r.URL.Path,
 					"client_addr", r.RemoteAddr,
 					"stack", string(debug.Stack()),
-				)
+				}
+				if calendarName, ok := calendarNameFromPath(r.URL.Path); ok {
+					logArgs = append(logArgs, "calendar", calendarName)
+				}
+
+				slog.Error("recovered panic while processing http request", logArgs...)
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -71,6 +71,9 @@ func TestRequestLoggingMiddlewareLogsPathWithoutQuery(t *testing.T) {
 	if !strings.Contains(got, "status=202") {
 		t.Fatalf("log output = %q, want status", got)
 	}
+	if !strings.Contains(got, "calendar=private") {
+		t.Fatalf("log output = %q, want calendar name", got)
+	}
 }
 
 func TestRequestLoggingMiddlewareSkipsHealthEndpoints(t *testing.T) {
@@ -134,8 +137,12 @@ func TestRequestLoggingMiddlewareLogsNonHealthEndpoint(t *testing.T) {
 
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
-	if got := logOutput.String(); !strings.Contains(got, "path=/liveness/extra") {
+	got := logOutput.String()
+	if !strings.Contains(got, "path=/liveness/extra") {
 		t.Fatalf("log output = %q, want non-health endpoint to be logged", got)
+	}
+	if strings.Contains(got, "calendar=") {
+		t.Fatalf("log output = %q, did not want calendar attribute", got)
 	}
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -178,6 +178,12 @@ func TestRecoveryMiddlewareReturnsInternalServerError(t *testing.T) {
 	if !strings.Contains(got, "panic=boom") {
 		t.Fatalf("log output = %q, want panic value", got)
 	}
+	if !strings.Contains(got, "method=GET") {
+		t.Fatalf("log output = %q, want request method", got)
+	}
+	if !strings.Contains(got, "calendar=private") {
+		t.Fatalf("log output = %q, want calendar name", got)
+	}
 	if !strings.Contains(got, "status=500") {
 		t.Fatalf("log output = %q, want request log status", got)
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -165,7 +165,7 @@ func TestRecoveryMiddlewareReturnsInternalServerError(t *testing.T) {
 	}
 
 	got := logOutput.String()
-	if !strings.Contains(got, "Recovered panic while processing HTTP request") {
+	if !strings.Contains(got, "recovered panic while processing http request") {
 		t.Fatalf("log output = %q, want recovery log", got)
 	}
 	if !strings.Contains(got, "panic=boom") {

--- a/routes.go
+++ b/routes.go
@@ -8,7 +8,7 @@ import (
 func registerPublicRoutes(mux *http.ServeMux, config RuntimeConfig, metrics *prometheusMetrics) {
 	for _, calendar := range config.Calendars {
 		httpPath := "/calendars/" + calendar.Name + "/feed"
-		slog.Debug("configuring endpoint", "calendar", calendar.Name, "http_path", httpPath)
+		slog.Debug("configuring endpoint", "calendar", calendar.Name, "path", httpPath)
 
 		fetch := calendar.fetch
 		if metrics != nil {

--- a/routes.go
+++ b/routes.go
@@ -8,7 +8,7 @@ import (
 func registerPublicRoutes(mux *http.ServeMux, config RuntimeConfig, metrics *prometheusMetrics) {
 	for _, calendar := range config.Calendars {
 		httpPath := "/calendars/" + calendar.Name + "/feed"
-		slog.Debug("Configuring endpoint", "calendar", calendar.Name, "http_path", httpPath)
+		slog.Debug("configuring endpoint", "calendar", calendar.Name, "http_path", httpPath)
 
 		fetch := calendar.fetch
 		if metrics != nil {

--- a/server.go
+++ b/server.go
@@ -73,7 +73,7 @@ func buildHTTPServers(config RuntimeConfig, address string, managementAddress st
 func runHTTPServers(servers ...managedHTTPServer) error {
 	serverErr := make(chan httpServerError, len(servers))
 	for _, managedServer := range servers {
-		slog.Info("Starting web server", "name", managedServer.name, "address", managedServer.server.Addr)
+		slog.Info("starting web server", "name", managedServer.name, "address", managedServer.server.Addr)
 		go func(managedServer managedHTTPServer) {
 			serverErr <- httpServerError{
 				name: managedServer.name,
@@ -92,16 +92,16 @@ func runHTTPServers(servers ...managedHTTPServer) error {
 			return fmt.Errorf("%s server: %w", err.name, err.err)
 		}
 	case sig := <-shutdownSignal:
-		slog.Info("Stopping web servers", "signal", sig.String())
+		slog.Info("stopping web servers", "signal", sig.String())
 
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 		defer cancel()
 
 		for _, managedServer := range servers {
 			if err := managedServer.server.Shutdown(shutdownCtx); err != nil {
-				slog.Error("Error stopping web server", "name", managedServer.name, "error", err)
+				slog.Error("web server shutdown failed", "name", managedServer.name, "error", err)
 				if closeErr := managedServer.server.Close(); closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
-					slog.Error("Error closing web server", "name", managedServer.name, "error", closeErr)
+					slog.Error("web server close failed", "name", managedServer.name, "error", closeErr)
 				}
 			}
 		}


### PR DESCRIPTION
This PR cleans up log message consistency and adds more useful structured context to request, handler, panic, and filter logs.

- normalize log messages to lower-case event-style phrasing
- rename `client_ip` to `client_addr` anywhere `RemoteAddr` is logged
- add `calendar` to relevant log messages
- add `method`, `path`, and `client_addr` to handler logs
- add `method` to panic recovery logs
- change route setup log field from `http_path` to `path`
- rename filter processing log field `rule_id` to `filter_index`
- standardize filter description field as `filter_description`
- lower missing event summary logs from warn to debug
- lowers no-filter/proxy-only config logs from warn to info