### PR TITLE
add support for X-Forwarded-For proxy headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Most runtime flags can also be set with environment variables. CLI flags take pr
 | `-metrics`                 | `ICAL_FILTER_PROXY_METRICS`                 | Enable Prometheus metrics.                              |
 | `-metrics-calendar-labels` | `ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS` | Enable per-calendar metric labels.                      |
 | `-management-address`      | `ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS`      | Address for liveness, readiness, and metrics endpoints. |
+| `-trusted-proxy-cidr`      | `ICAL_FILTER_PROXY_TRUSTED_PROXY_CIDRS`     | Trusted reverse proxy CIDRs for forwarded addresses.    |
 
 `-version` is CLI-only.
 

--- a/client_addr.go
+++ b/client_addr.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+func requestClientAddr(r *http.Request, trustedProxyCIDRs []netip.Prefix) string {
+	remoteAddr := r.RemoteAddr
+	remoteIP, ok := parseRemoteAddrIP(remoteAddr)
+	if !ok || !isTrustedProxy(remoteIP, trustedProxyCIDRs) {
+		return remoteAddr
+	}
+
+	forwardedAddrs, ok := parseForwardedForAddrs(r.Header.Values("X-Forwarded-For"))
+	if !ok || len(forwardedAddrs) == 0 {
+		return remoteAddr
+	}
+
+	for i := len(forwardedAddrs) - 1; i >= 0; i-- {
+		if !isTrustedProxy(forwardedAddrs[i], trustedProxyCIDRs) {
+			return forwardedAddrs[i].String()
+		}
+	}
+
+	return forwardedAddrs[0].String()
+}
+
+func parseRemoteAddrIP(remoteAddr string) (netip.Addr, bool) {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return netip.Addr{}, false
+	}
+
+	return addr.Unmap(), true
+}
+
+func parseForwardedForAddrs(values []string) ([]netip.Addr, bool) {
+	addrs := []netip.Addr{}
+	for _, value := range values {
+		parts := strings.Split(value, ",")
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+
+			addr, err := netip.ParseAddr(strings.Trim(part, "[]"))
+			if err != nil {
+				return nil, false
+			}
+			addrs = append(addrs, addr.Unmap())
+		}
+	}
+
+	return addrs, true
+}
+
+func isTrustedProxy(addr netip.Addr, trustedProxyCIDRs []netip.Prefix) bool {
+	for _, prefix := range trustedProxyCIDRs {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/client_addr_test.go
+++ b/client_addr_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net/http"
+	"net/netip"
+	"testing"
+)
+
+func TestRequestClientAddrUsesRemoteAddrByDefault(t *testing.T) {
+	req := clientAddrRequest("198.51.100.10:12345", "203.0.113.9")
+
+	if got, want := requestClientAddr(req, nil), "198.51.100.10:12345"; got != want {
+		t.Fatalf("requestClientAddr() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestClientAddrIgnoresForwardedForFromUntrustedRemote(t *testing.T) {
+	req := clientAddrRequest("198.51.100.10:12345", "203.0.113.9")
+
+	if got, want := requestClientAddr(req, mustPrefixes(t, "10.0.0.0/8")), "198.51.100.10:12345"; got != want {
+		t.Fatalf("requestClientAddr() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestClientAddrUsesForwardedForFromTrustedRemote(t *testing.T) {
+	req := clientAddrRequest("10.0.0.10:12345", "203.0.113.9")
+
+	if got, want := requestClientAddr(req, mustPrefixes(t, "10.0.0.0/8")), "203.0.113.9"; got != want {
+		t.Fatalf("requestClientAddr() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestClientAddrSelectsNearestUntrustedForwardedFor(t *testing.T) {
+	req := clientAddrRequest("10.0.0.10:12345", "198.51.100.1, 192.0.2.10")
+
+	trustedProxyCIDRs := mustPrefixes(t, "10.0.0.0/8", "192.0.2.0/24")
+	if got, want := requestClientAddr(req, trustedProxyCIDRs), "198.51.100.1"; got != want {
+		t.Fatalf("requestClientAddr() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestClientAddrFallsBackForInvalidForwardedFor(t *testing.T) {
+	req := clientAddrRequest("10.0.0.10:12345", "203.0.113.9, not-an-ip")
+
+	if got, want := requestClientAddr(req, mustPrefixes(t, "10.0.0.0/8")), "10.0.0.10:12345"; got != want {
+		t.Fatalf("requestClientAddr() = %q, want %q", got, want)
+	}
+}
+
+func clientAddrRequest(remoteAddr string, forwardedFor string) *http.Request {
+	req := &http.Request{
+		RemoteAddr: remoteAddr,
+		Header:     http.Header{},
+	}
+	if forwardedFor != "" {
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+	}
+
+	return req
+}
+
+func mustPrefixes(t *testing.T, cidrs ...string) []netip.Prefix {
+	t.Helper()
+
+	prefixes := make([]netip.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			t.Fatalf("ParsePrefix(%q) returned error: %v", cidr, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+
+	return prefixes
+}

--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"log/slog"
 	"net/http"
+	"net/netip"
 )
 
 const (
@@ -15,7 +16,7 @@ const (
 
 type calendarFetchFunc func(context.Context) ([]byte, error)
 
-func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) http.HandlerFunc {
+func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc, trustedProxyCIDRs []netip.Prefix) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setCommonResponseHeaders(w)
 
@@ -26,7 +27,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		}
 
 		if !calendar.Public && !tokenMatches(r.URL.Query().Get("token"), calendar.Token) {
-			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", r.RemoteAddr)
+			slog.Warn("unauthorized calendar access", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", requestClientAddr(r, trustedProxyCIDRs))
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -34,7 +35,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 		// fetch and filter upstream calendar
 		feed, err := fetch(r.Context())
 		if err != nil {
-			slog.Error("calendar feed request failed", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", r.RemoteAddr, "error", err)
+			slog.Error("calendar feed request failed", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", requestClientAddr(r, trustedProxyCIDRs), "error", err)
 			http.Error(w, "Bad Gateway", http.StatusBadGateway)
 			return
 		}
@@ -47,7 +48,7 @@ func calendarFeedHandlerWithFetch(calendar Calendar, fetch calendarFetchFunc) ht
 
 		_, err = w.Write(feed)
 		if err != nil {
-			slog.Error("calendar feed response write failed", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", r.RemoteAddr, "error", err)
+			slog.Error("calendar feed response write failed", "calendar", calendar.Name, "method", r.Method, "path", r.URL.Path, "client_addr", requestClientAddr(r, trustedProxyCIDRs), "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -59,6 +59,7 @@ func TestCalendarFeedHandlerUnauthorized(t *testing.T) {
 			fetchCalled = true
 			return []byte("should not be called"), nil
 		},
+		nil,
 	)
 
 	req := testRequest(t, "/calendars/private/feed?token=wrong")
@@ -81,6 +82,7 @@ func TestCalendarFeedHandlerSuccess(t *testing.T) {
 		func(context.Context) ([]byte, error) {
 			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
 		},
+		nil,
 	)
 
 	req := testRequest(t, "/calendars/private/feed?token=secret")
@@ -106,6 +108,7 @@ func TestCalendarFeedHandlerHeadSuccess(t *testing.T) {
 		func(context.Context) ([]byte, error) {
 			return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
 		},
+		nil,
 	)
 
 	req := testRequestWithMethod(t, http.MethodHead, "/calendars/private/feed?token=secret")
@@ -133,6 +136,7 @@ func TestCalendarFeedHandlerMethodNotAllowed(t *testing.T) {
 			fetchCalled = true
 			return []byte("should not be called"), nil
 		},
+		nil,
 	)
 
 	req := testRequestWithMethod(t, http.MethodPost, "/calendars/private/feed?token=secret")
@@ -174,6 +178,7 @@ func TestCalendarFeedHandlerPublicCalendarIgnoresToken(t *testing.T) {
 				func(context.Context) ([]byte, error) {
 					return []byte("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"), nil
 				},
+				nil,
 			)
 
 			req := testRequest(t, tt.target)
@@ -194,6 +199,7 @@ func TestCalendarFeedHandlerUpstreamError(t *testing.T) {
 		func(context.Context) ([]byte, error) {
 			return nil, errors.New("upstream failed")
 		},
+		nil,
 	)
 
 	req := testRequest(t, "/calendars/private/feed?token=secret")

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 		slog.Warn("Prometheus metrics endpoint enabled on public listener; set -management-address to expose management endpoints separately")
 	}
 
-	servers := buildHTTPServers(runtimeConfig, options.address, options.managementAddress, metrics)
+	servers := buildHTTPServers(runtimeConfig, options.address, options.managementAddress, metrics, options.trustedProxyCIDRs)
 	if err := runHTTPServers(servers...); err != nil {
 		slog.Error("web server failed", "error", err)
 		os.Exit(1)

--- a/middleware.go
+++ b/middleware.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"runtime/debug"
 	"time"
 )
@@ -26,7 +27,7 @@ func (r *statusRecorder) Write(body []byte) (int, error) {
 	return r.ResponseWriter.Write(body)
 }
 
-func requestLoggingMiddleware(next http.Handler) http.Handler {
+func requestLoggingMiddleware(next http.Handler, trustedProxyCIDRs []netip.Prefix) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isHealthEndpoint(r.URL.Path) {
 			next.ServeHTTP(w, r)
@@ -48,7 +49,7 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 			"path", r.URL.Path,
 			"status", statusCode,
 			"duration_ms", time.Since(startedAt).Milliseconds(),
-			"client_addr", r.RemoteAddr,
+			"client_addr", requestClientAddr(r, trustedProxyCIDRs),
 			"user_agent", r.UserAgent(),
 		}
 		if calendarName, ok := calendarNameFromPath(r.URL.Path); ok {
@@ -59,7 +60,7 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func recoveryMiddleware(next http.Handler) http.Handler {
+func recoveryMiddleware(next http.Handler, trustedProxyCIDRs []netip.Prefix) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
@@ -67,7 +68,7 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 					"panic", fmt.Sprint(recovered),
 					"method", r.Method,
 					"path", r.URL.Path,
-					"client_addr", r.RemoteAddr,
+					"client_addr", requestClientAddr(r, trustedProxyCIDRs),
 					"stack", string(debug.Stack()),
 				}
 				if calendarName, ok := calendarNameFromPath(r.URL.Path); ok {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -51,7 +51,7 @@ func TestRequestLoggingMiddlewareLogsPathWithoutQuery(t *testing.T) {
 
 	handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
-	}))
+	}), nil)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/calendars/private/feed?token=secret", nil)
 	if err != nil {
@@ -102,7 +102,7 @@ func TestRequestLoggingMiddlewareSkipsHealthEndpoints(t *testing.T) {
 
 			handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
-			}))
+			}), nil)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tt.path, nil)
 			if err != nil {
@@ -128,7 +128,7 @@ func TestRequestLoggingMiddlewareLogsNonHealthEndpoint(t *testing.T) {
 
 	handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
+	}), nil)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/liveness/extra", nil)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestRecoveryMiddlewareReturnsInternalServerError(t *testing.T) {
 
 	handler := requestLoggingMiddleware(recoveryMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("boom")
-	})))
+	}), nil), nil)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/calendars/private/feed", nil)
 	if err != nil {
@@ -192,7 +192,7 @@ func TestRecoveryMiddlewareReturnsInternalServerError(t *testing.T) {
 func TestRecoveryMiddlewarePassesThrough(t *testing.T) {
 	handler := recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	}), nil)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/calendars/private/feed", nil)
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/netip"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -15,6 +17,7 @@ const (
 	envMetrics               = "ICAL_FILTER_PROXY_METRICS"
 	envMetricsCalendarLabels = "ICAL_FILTER_PROXY_METRICS_CALENDAR_LABELS"
 	envManagementAddress     = "ICAL_FILTER_PROXY_MANAGEMENT_ADDRESS"
+	envTrustedProxyCIDRs     = "ICAL_FILTER_PROXY_TRUSTED_PROXY_CIDRS"
 )
 
 type appOptions struct {
@@ -27,6 +30,7 @@ type appOptions struct {
 	metricsEnabled         bool
 	calendarMetricsEnabled bool
 	managementAddress      string
+	trustedProxyCIDRs      []netip.Prefix
 }
 
 type envLookupFunc func(string) (string, bool)
@@ -47,9 +51,18 @@ func parseOptions(args []string, lookupEnv envLookupFunc) (appOptions, error) {
 	flags.BoolVar(&options.metricsEnabled, "metrics", options.metricsEnabled, "enable prometheus metrics endpoint")
 	flags.BoolVar(&options.calendarMetricsEnabled, "metrics-calendar-labels", options.calendarMetricsEnabled, "enable per-calendar prometheus metrics")
 	flags.StringVar(&options.managementAddress, "management-address", options.managementAddress, "optional address for liveness, readiness, and metrics endpoints")
+	trustedProxyCIDRs := stringListFlag{}
+	flags.Var(&trustedProxyCIDRs, "trusted-proxy-cidr", "trusted reverse proxy CIDR for forwarded client address handling; may be repeated")
 
 	if err := flags.Parse(args); err != nil {
 		return appOptions{}, err
+	}
+
+	if trustedProxyCIDRs.set {
+		options.trustedProxyCIDRs, err = parseTrustedProxyCIDRs(trustedProxyCIDRs.values)
+		if err != nil {
+			return appOptions{}, err
+		}
 	}
 
 	return options, nil
@@ -66,6 +79,9 @@ func defaultOptionsFromEnv(lookupEnv envLookupFunc) (appOptions, error) {
 	options.managementAddress = envString(lookupEnv, envManagementAddress, options.managementAddress)
 
 	var err error
+	if options.trustedProxyCIDRs, err = parseTrustedProxyCIDRs(envStringList(lookupEnv, envTrustedProxyCIDRs)); err != nil {
+		return appOptions{}, err
+	}
 	if options.debugLogging, err = envBool(lookupEnv, envDebug, options.debugLogging); err != nil {
 		return appOptions{}, err
 	}
@@ -85,6 +101,21 @@ func defaultOptionsFromEnv(lookupEnv envLookupFunc) (appOptions, error) {
 	return options, nil
 }
 
+type stringListFlag struct {
+	values []string
+	set    bool
+}
+
+func (f *stringListFlag) String() string {
+	return strings.Join(f.values, ",")
+}
+
+func (f *stringListFlag) Set(value string) error {
+	f.set = true
+	f.values = append(f.values, value)
+	return nil
+}
+
 func envString(lookupEnv envLookupFunc, name string, fallback string) string {
 	value, ok := lookupEnv(name)
 	if !ok {
@@ -92,6 +123,24 @@ func envString(lookupEnv envLookupFunc, name string, fallback string) string {
 	}
 
 	return value
+}
+
+func envStringList(lookupEnv envLookupFunc, name string) []string {
+	value, ok := lookupEnv(name)
+	if !ok || strings.TrimSpace(value) == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+
+	return values
 }
 
 func envBool(lookupEnv envLookupFunc, name string, fallback bool) (bool, error) {
@@ -106,4 +155,17 @@ func envBool(lookupEnv envLookupFunc, name string, fallback bool) (bool, error) 
 	}
 
 	return parsed, nil
+}
+
+func parseTrustedProxyCIDRs(cidrs []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid trusted proxy CIDR %q: %w", cidr, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+
+	return prefixes, nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
 )
@@ -35,6 +36,7 @@ func TestParseOptionsUsesEnvironmentDefaults(t *testing.T) {
 		envMetrics:               "true",
 		envMetricsCalendarLabels: "true",
 		envManagementAddress:     "127.0.0.1:9090",
+		envTrustedProxyCIDRs:     "127.0.0.1/32, 10.0.0.0/8",
 	}
 
 	options, err := parseOptions(nil, mapEnv(env))
@@ -51,6 +53,9 @@ func TestParseOptionsUsesEnvironmentDefaults(t *testing.T) {
 	if options.managementAddress != "127.0.0.1:9090" {
 		t.Fatalf("managementAddress = %q, want env value", options.managementAddress)
 	}
+	if got, want := strings.Join(prefixStrings(options.trustedProxyCIDRs), ","), "127.0.0.1/32,10.0.0.0/8"; got != want {
+		t.Fatalf("trustedProxyCIDRs = %q, want %q", got, want)
+	}
 	if !options.debugLogging || !options.jsonLogging || !options.validateConfig || !options.metricsEnabled || !options.calendarMetricsEnabled {
 		t.Fatalf("boolean options = %+v, want all env booleans true", options)
 	}
@@ -63,6 +68,7 @@ func TestParseOptionsCLIOverridesEnvironment(t *testing.T) {
 		envDebug:             "true",
 		envMetrics:           "true",
 		envManagementAddress: "127.0.0.1:9090",
+		envTrustedProxyCIDRs: "10.0.0.0/8",
 	}
 
 	options, err := parseOptions([]string{
@@ -71,6 +77,8 @@ func TestParseOptionsCLIOverridesEnvironment(t *testing.T) {
 		"-debug=false",
 		"-metrics=false",
 		"-management-address", "127.0.0.1:9091",
+		"-trusted-proxy-cidr", "127.0.0.1/32",
+		"-trusted-proxy-cidr", "192.0.2.0/24",
 	}, mapEnv(env))
 	if err != nil {
 		t.Fatalf("parseOptions() returned error: %v", err)
@@ -91,6 +99,9 @@ func TestParseOptionsCLIOverridesEnvironment(t *testing.T) {
 	if options.managementAddress != "127.0.0.1:9091" {
 		t.Fatalf("managementAddress = %q, want CLI value", options.managementAddress)
 	}
+	if got, want := strings.Join(prefixStrings(options.trustedProxyCIDRs), ","), "127.0.0.1/32,192.0.2.0/24"; got != want {
+		t.Fatalf("trustedProxyCIDRs = %q, want CLI values %q", got, want)
+	}
 }
 
 func TestParseOptionsRejectsInvalidBoolEnvironment(t *testing.T) {
@@ -102,6 +113,28 @@ func TestParseOptionsRejectsInvalidBoolEnvironment(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), envDebug) {
 		t.Fatalf("parseOptions() error = %q, want env var name", err)
+	}
+}
+
+func TestParseOptionsRejectsInvalidTrustedProxyCIDREnvironment(t *testing.T) {
+	_, err := parseOptions(nil, mapEnv(map[string]string{
+		envTrustedProxyCIDRs: "not-a-cidr",
+	}))
+	if err == nil {
+		t.Fatal("parseOptions() returned nil error")
+	}
+	if !strings.Contains(err.Error(), "not-a-cidr") {
+		t.Fatalf("parseOptions() error = %q, want invalid CIDR value", err)
+	}
+}
+
+func TestParseOptionsRejectsInvalidTrustedProxyCIDRFlag(t *testing.T) {
+	_, err := parseOptions([]string{"-trusted-proxy-cidr", "not-a-cidr"}, emptyEnv)
+	if err == nil {
+		t.Fatal("parseOptions() returned nil error")
+	}
+	if !strings.Contains(err.Error(), "not-a-cidr") {
+		t.Fatalf("parseOptions() error = %q, want invalid CIDR value", err)
 	}
 }
 
@@ -134,4 +167,13 @@ func mapEnv(values map[string]string) envLookupFunc {
 		value, ok := values[name]
 		return value, ok
 	}
+}
+
+func prefixStrings(prefixes []netip.Prefix) []string {
+	values := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		values = append(values, prefix.String())
+	}
+
+	return values
 }

--- a/routes.go
+++ b/routes.go
@@ -3,9 +3,10 @@ package main
 import (
 	"log/slog"
 	"net/http"
+	"net/netip"
 )
 
-func registerPublicRoutes(mux *http.ServeMux, config RuntimeConfig, metrics *prometheusMetrics) {
+func registerPublicRoutes(mux *http.ServeMux, config RuntimeConfig, metrics *prometheusMetrics, trustedProxyCIDRs []netip.Prefix) {
 	for _, calendar := range config.Calendars {
 		httpPath := "/calendars/" + calendar.Name + "/feed"
 		slog.Debug("configuring endpoint", "calendar", calendar.Name, "path", httpPath)
@@ -15,7 +16,7 @@ func registerPublicRoutes(mux *http.ServeMux, config RuntimeConfig, metrics *pro
 			fetch = metrics.instrumentFetch(calendar.Name, fetch)
 		}
 
-		mux.HandleFunc(httpPath, calendarFeedHandlerWithFetch(calendar, fetch))
+		mux.HandleFunc(httpPath, calendarFeedHandlerWithFetch(calendar, fetch, trustedProxyCIDRs))
 	}
 }
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -15,7 +15,7 @@ func TestRegisterPublicRoutesRegistersCalendarFeeds(t *testing.T) {
 				Token: "secret",
 			},
 		},
-	}, nil)
+	}, nil, nil)
 
 	req := testRequest(t, "/calendars/private/feed")
 	rr := httptest.NewRecorder()
@@ -68,7 +68,7 @@ func TestPublicAndInternalRoutesCanUseSeparateMuxes(t *testing.T) {
 				Token: "secret",
 			},
 		},
-	}, nil)
+	}, nil, nil)
 
 	internalMux := http.NewServeMux()
 	registerInternalRoutes(internalMux, nil)

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,23 +36,23 @@ func newHTTPServer(address string, handler http.Handler) *http.Server {
 	}
 }
 
-func buildHTTPHandler(listener string, handler http.Handler, metrics *prometheusMetrics) http.Handler {
-	handler = recoveryMiddleware(handler)
+func buildHTTPHandler(listener string, handler http.Handler, metrics *prometheusMetrics, trustedProxyCIDRs []netip.Prefix) http.Handler {
+	handler = recoveryMiddleware(handler, trustedProxyCIDRs)
 	if metrics != nil {
 		handler = metrics.middleware(listener, handler)
 	}
 
-	return requestLoggingMiddleware(handler)
+	return requestLoggingMiddleware(handler, trustedProxyCIDRs)
 }
 
-func buildHTTPServers(config RuntimeConfig, address string, managementAddress string, metrics *prometheusMetrics) []managedHTTPServer {
+func buildHTTPServers(config RuntimeConfig, address string, managementAddress string, metrics *prometheusMetrics, trustedProxyCIDRs []netip.Prefix) []managedHTTPServer {
 	publicMux := http.NewServeMux()
-	registerPublicRoutes(publicMux, config, metrics)
+	registerPublicRoutes(publicMux, config, metrics, trustedProxyCIDRs)
 
 	servers := []managedHTTPServer{
 		{
 			name:   "public",
-			server: newHTTPServer(address, buildHTTPHandler("public", publicMux, metrics)),
+			server: newHTTPServer(address, buildHTTPHandler("public", publicMux, metrics, trustedProxyCIDRs)),
 		},
 	}
 
@@ -66,7 +67,7 @@ func buildHTTPServers(config RuntimeConfig, address string, managementAddress st
 	registerInternalRoutes(managementMux, metrics)
 	return append(servers, managedHTTPServer{
 		name:   "management",
-		server: newHTTPServer(managementAddress, buildHTTPHandler("management", managementMux, metrics)),
+		server: newHTTPServer(managementAddress, buildHTTPHandler("management", managementMux, metrics, trustedProxyCIDRs)),
 	})
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -28,7 +28,7 @@ func TestNewHTTPServerSetsTimeouts(t *testing.T) {
 }
 
 func TestBuildHTTPServersRegistersInternalRoutesOnPublicServerByDefault(t *testing.T) {
-	servers := buildHTTPServers(testServerConfig(), ":8080", "", nil)
+	servers := buildHTTPServers(testServerConfig(), ":8080", "", nil, nil)
 
 	if len(servers) != 1 {
 		t.Fatalf("server count = %d, want 1", len(servers))
@@ -45,7 +45,7 @@ func TestBuildHTTPServersRegistersInternalRoutesOnPublicServerByDefault(t *testi
 }
 
 func TestBuildHTTPServersSeparatesManagementRoutes(t *testing.T) {
-	servers := buildHTTPServers(testServerConfig(), ":8080", "127.0.0.1:9090", nil)
+	servers := buildHTTPServers(testServerConfig(), ":8080", "127.0.0.1:9090", nil, nil)
 
 	if len(servers) != 2 {
 		t.Fatalf("server count = %d, want 2", len(servers))


### PR DESCRIPTION
Adds support for `X-Forwarded-For` proxy headers used to log `client_addr`. May be useful for future ip acl or similar. Only trusts headers from explicitly allowed CIDRs.

- add `-trusted-proxy-cidr` to specify one or more trusted CIDRs
- add `ICAL_FILTER_PROXY_TRUSTED_PROXY_CIDRS` env support for comma-separated CIDR list