### PR TITLE
feat: support contains_all and contains_any string match conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ These match conditions are available for a string value:
 
 - `empty` - if `true`, property must be absent or empty
 - `contains` - property must contain this value
+- `contains_any` - property must contain at least one value from this list
+- `contains_all` - property must contain every value from this list
 - `prefix` - property must start with this value
 - `suffix` - property must end with this value
 - `regex` - property must match the given regular expression. Invalid regular expressions are rejected when the configuration is loaded.

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1,5 +1,40 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "stringMatchRule": {
+      "additionalProperties": false,
+      "properties": {
+        "empty": {
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "contains": {
+          "type": "string"
+        },
+        "contains_any": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "contains_all": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "regex": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
   "properties": {
     "affinity": {
       "properties": {},
@@ -54,136 +89,16 @@
                       "additionalProperties": false,
                       "properties": {
                         "summary": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "empty": {
-                              "type": "boolean"
-                            },
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "suffix": {
-                              "type": "string"
-                            },
-                            "contains": {
-                              "type": "string"
-                            },
-                            "contains_any": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "contains_all": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "regex": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringMatchRule"
                         },
                         "description": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "empty": {
-                              "type": "boolean"
-                            },
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "suffix": {
-                              "type": "string"
-                            },
-                            "contains": {
-                              "type": "string"
-                            },
-                            "contains_any": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "contains_all": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "regex": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringMatchRule"
                         },
                         "location": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "empty": {
-                              "type": "boolean"
-                            },
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "suffix": {
-                              "type": "string"
-                            },
-                            "contains": {
-                              "type": "string"
-                            },
-                            "contains_any": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "contains_all": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "regex": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringMatchRule"
                         },
                         "url": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "empty": {
-                              "type": "boolean"
-                            },
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "suffix": {
-                              "type": "string"
-                            },
-                            "contains": {
-                              "type": "string"
-                            },
-                            "contains_any": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "contains_all": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "regex": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringMatchRule"
                         }
                       },
                       "type": "object"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -68,6 +68,18 @@
                             "contains": {
                               "type": "string"
                             },
+                            "contains_any": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "contains_all": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "regex": {
                               "type": "string"
                             }
@@ -88,6 +100,18 @@
                             },
                             "contains": {
                               "type": "string"
+                            },
+                            "contains_any": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "contains_all": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "regex": {
                               "type": "string"
@@ -110,6 +134,18 @@
                             "contains": {
                               "type": "string"
                             },
+                            "contains_any": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "contains_all": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "regex": {
                               "type": "string"
                             }
@@ -130,6 +166,18 @@
                             },
                             "contains": {
                               "type": "string"
+                            },
+                            "contains_any": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "contains_all": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "regex": {
                               "type": "string"

--- a/string_rules.go
+++ b/string_rules.go
@@ -9,28 +9,41 @@ import (
 // StringMatchRuleConfig is the YAML-backed string match configuration. Regex values
 // are compiled into StringMatchRule during runtime config preparation.
 type StringMatchRuleConfig struct {
-	Null       bool   `yaml:"empty"`
-	Contains   string `yaml:"contains"`
-	Prefix     string `yaml:"prefix"`
-	Suffix     string `yaml:"suffix"`
-	RegexMatch string `yaml:"regex"`
+	Null        bool     `yaml:"empty"`
+	Contains    string   `yaml:"contains"`
+	ContainsAny []string `yaml:"contains_any"`
+	ContainsAll []string `yaml:"contains_all"`
+	Prefix      string   `yaml:"prefix"`
+	Suffix      string   `yaml:"suffix"`
+	RegexMatch  string   `yaml:"regex"`
 }
 
 // Returns true if StringMatchRuleConfig has any conditions
 func (smr StringMatchRuleConfig) hasConditions() bool {
 	return smr.Null ||
 		smr.Contains != "" ||
+		len(smr.ContainsAny) > 0 ||
+		len(smr.ContainsAll) > 0 ||
 		smr.Prefix != "" ||
 		smr.Suffix != "" ||
 		smr.RegexMatch != ""
 }
 
 func (smr StringMatchRuleConfig) compile() (StringMatchRule, error) {
+	if err := validateStringList("contains_any", smr.ContainsAny); err != nil {
+		return StringMatchRule{}, err
+	}
+	if err := validateStringList("contains_all", smr.ContainsAll); err != nil {
+		return StringMatchRule{}, err
+	}
+
 	rule := StringMatchRule{
-		Null:     smr.Null,
-		Contains: smr.Contains,
-		Prefix:   smr.Prefix,
-		Suffix:   smr.Suffix,
+		Null:        smr.Null,
+		Contains:    smr.Contains,
+		ContainsAny: append([]string(nil), smr.ContainsAny...),
+		ContainsAll: append([]string(nil), smr.ContainsAll...),
+		Prefix:      smr.Prefix,
+		Suffix:      smr.Suffix,
 	}
 
 	if smr.RegexMatch == "" {
@@ -46,6 +59,16 @@ func (smr StringMatchRuleConfig) compile() (StringMatchRule, error) {
 	return rule, nil
 }
 
+func validateStringList(name string, values []string) error {
+	for i, value := range values {
+		if value == "" {
+			return fmt.Errorf("%s[%d] must not be empty", name, i)
+		}
+	}
+
+	return nil
+}
+
 // Returns true if a given string (data) matches ALL StringMatchRuleConfig conditions
 func (smr StringMatchRuleConfig) matchesString(data string) bool {
 	rule, err := smr.compile()
@@ -59,16 +82,20 @@ func (smr StringMatchRuleConfig) matchesString(data string) bool {
 // StringMatchRule is the runtime string matcher. Regex is compiled once
 // so event processing can match without reparsing configuration.
 type StringMatchRule struct {
-	Null     bool
-	Contains string
-	Prefix   string
-	Suffix   string
-	Regex    *regexp.Regexp
+	Null        bool
+	Contains    string
+	ContainsAny []string
+	ContainsAll []string
+	Prefix      string
+	Suffix      string
+	Regex       *regexp.Regexp
 }
 
 func (rule StringMatchRule) hasConditions() bool {
 	return rule.Null ||
 		rule.Contains != "" ||
+		len(rule.ContainsAny) > 0 ||
+		len(rule.ContainsAll) > 0 ||
 		rule.Prefix != "" ||
 		rule.Suffix != "" ||
 		rule.Regex != nil
@@ -83,6 +110,33 @@ func (rule StringMatchRule) matchesString(data string) bool {
 	if rule.Contains != "" {
 		if data == "" || !strings.Contains(data, rule.Contains) {
 			return false
+		}
+	}
+	// check contains_any if set
+	if len(rule.ContainsAny) > 0 {
+		if data == "" {
+			return false
+		}
+		containsAny := false
+		for _, value := range rule.ContainsAny {
+			if strings.Contains(data, value) {
+				containsAny = true
+				break
+			}
+		}
+		if !containsAny {
+			return false
+		}
+	}
+	// check contains_all if set
+	if len(rule.ContainsAll) > 0 {
+		if data == "" {
+			return false
+		}
+		for _, value := range rule.ContainsAll {
+			if !strings.Contains(data, value) {
+				return false
+			}
 		}
 	}
 	// check prefix if set

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -24,6 +24,16 @@ func TestStringMatchRuleConfigHasConditions(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "contains_any condition",
+			rule: StringMatchRuleConfig{ContainsAny: []string{"event"}},
+			want: true,
+		},
+		{
+			name: "contains_all condition",
+			rule: StringMatchRuleConfig{ContainsAll: []string{"event"}},
+			want: true,
+		},
+		{
 			name: "prefix condition",
 			rule: StringMatchRuleConfig{Prefix: "event"},
 			want: true,
@@ -69,10 +79,60 @@ func TestStringMatchRuleConfigCompile(t *testing.T) {
 	}
 }
 
+func TestStringMatchRuleConfigCompileCopiesContainsSlices(t *testing.T) {
+	config := StringMatchRuleConfig{
+		ContainsAny: []string{"calendar"},
+		ContainsAll: []string{"team", "event"},
+	}
+
+	rule, err := config.compile()
+	if err != nil {
+		t.Fatalf("compile() returned error: %v", err)
+	}
+
+	config.ContainsAny[0] = "changed"
+	config.ContainsAll[0] = "changed"
+
+	if !rule.matchesString("team calendar event") {
+		t.Fatal("compiled rule changed after config slice mutation")
+	}
+}
+
 func TestStringMatchRuleConfigCompileInvalidRegex(t *testing.T) {
 	_, err := (StringMatchRuleConfig{RegexMatch: `[`}).compile()
 	if err == nil {
 		t.Fatal("compile() returned nil error")
+	}
+}
+
+func TestStringMatchRuleConfigCompileRejectsEmptyContainsListValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    StringMatchRuleConfig
+		wantErr string
+	}{
+		{
+			name:    "contains_any empty value",
+			rule:    StringMatchRuleConfig{ContainsAny: []string{"calendar", ""}},
+			wantErr: "contains_any[1] must not be empty",
+		},
+		{
+			name:    "contains_all empty value",
+			rule:    StringMatchRuleConfig{ContainsAll: []string{"", "event"}},
+			wantErr: "contains_all[0] must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.rule.compile()
+			if err == nil {
+				t.Fatal("compile() returned nil error")
+			}
+			if err.Error() != tt.wantErr {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -126,6 +186,60 @@ func TestStringMatchRuleConfigMatchesString(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "contains_any matches first value",
+			rule: StringMatchRuleConfig{ContainsAny: []string{"calendar", "holiday"}},
+			data: "calendar event",
+			want: true,
+		},
+		{
+			name: "contains_any matches later value",
+			rule: StringMatchRuleConfig{ContainsAny: []string{"holiday", "event"}},
+			data: "calendar event",
+			want: true,
+		},
+		{
+			name: "contains_any rejects missing values",
+			rule: StringMatchRuleConfig{ContainsAny: []string{"shift", "holiday"}},
+			data: "calendar event",
+			want: false,
+		},
+		{
+			name: "contains_any rejects empty data",
+			rule: StringMatchRuleConfig{ContainsAny: []string{"event"}},
+			data: "",
+			want: false,
+		},
+		{
+			name: "empty contains_any list is ignored",
+			rule: StringMatchRuleConfig{ContainsAny: []string{}},
+			data: "calendar event",
+			want: true,
+		},
+		{
+			name: "contains_all matches all values",
+			rule: StringMatchRuleConfig{ContainsAll: []string{"calendar", "event"}},
+			data: "calendar event",
+			want: true,
+		},
+		{
+			name: "contains_all rejects missing value",
+			rule: StringMatchRuleConfig{ContainsAll: []string{"calendar", "shift"}},
+			data: "calendar event",
+			want: false,
+		},
+		{
+			name: "contains_all rejects empty data",
+			rule: StringMatchRuleConfig{ContainsAll: []string{"event"}},
+			data: "",
+			want: false,
+		},
+		{
+			name: "empty contains_all list is ignored",
+			rule: StringMatchRuleConfig{ContainsAll: []string{}},
+			data: "calendar event",
+			want: true,
+		},
+		{
 			name: "prefix matches",
 			rule: StringMatchRuleConfig{Prefix: "calendar"},
 			data: "calendar event",
@@ -168,12 +282,26 @@ func TestStringMatchRuleConfigMatchesString(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "contains_any with empty value rejects",
+			rule: StringMatchRuleConfig{ContainsAny: []string{""}},
+			data: "calendar event",
+			want: false,
+		},
+		{
+			name: "contains_all with empty value rejects",
+			rule: StringMatchRuleConfig{ContainsAll: []string{""}},
+			data: "calendar event",
+			want: false,
+		},
+		{
 			name: "combined conditions all match",
 			rule: StringMatchRuleConfig{
-				Contains:   "calendar",
-				Prefix:     "team",
-				Suffix:     "event",
-				RegexMatch: `team .* event`,
+				Contains:    "calendar",
+				ContainsAny: []string{"meeting", "event"},
+				ContainsAll: []string{"team", "calendar"},
+				Prefix:      "team",
+				Suffix:      "event",
+				RegexMatch:  `team .* event`,
 			},
 			data: "team calendar event",
 			want: true,
@@ -181,10 +309,12 @@ func TestStringMatchRuleConfigMatchesString(t *testing.T) {
 		{
 			name: "combined conditions reject partial match",
 			rule: StringMatchRuleConfig{
-				Contains:   "calendar",
-				Prefix:     "team",
-				Suffix:     "shift",
-				RegexMatch: `team .* event`,
+				Contains:    "calendar",
+				ContainsAny: []string{"meeting", "event"},
+				ContainsAll: []string{"team", "calendar"},
+				Prefix:      "team",
+				Suffix:      "shift",
+				RegexMatch:  `team .* event`,
 			},
 			data: "team calendar event",
 			want: false,


### PR DESCRIPTION
Adds support for new string match conditions:
 - `contains_any`: matches when the field contains at least one listed value
 - `contains_all`: matches when the field contains every listed value

Closes #36

