### PR TITLE
feat: support trim prefix/suffix and replace string transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,15 @@ Transformations can be applied to the following event properties:
 
 The following transformations are available for strings:
 
-- `replace` - the property is replace with this value
-- `remove` - if `true` the property is set to a blank string
+- `remove` - if `true` the property is set to a blank string. This takes precedence over all other transform options.
+- `replace` - the property is replaced with this value. This takes precedence over `trim_prefix`, `trim_suffix`, `replace_text`, `prefix`, and `suffix`.
+- `trim_prefix` - remove this value when the property starts with it
+- `trim_suffix` - remove this value when the property ends with it
+- `replace_text` - replace literal text within the property. `old` is required, `new` is the replacement, and `all: true` replaces every occurrence instead of only the first.
 - `prefix` - this value is added before the existing property value
 - `suffix` - this value is added after the existing property value
+
+When `remove` and `replace` are not set, string transforms are applied in this order: `trim_prefix`, `trim_suffix`, `replace_text`, `prefix`, `suffix`.
 
 ### Secrets
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -33,6 +33,49 @@
         }
       },
       "type": "object"
+    },
+    "stringTransformRule": {
+      "additionalProperties": false,
+      "properties": {
+        "prefix": {
+          "type": "string"
+        },
+        "replace": {
+          "type": "string"
+        },
+        "remove": {
+          "type": "boolean"
+        },
+        "replace_text": {
+          "additionalProperties": false,
+          "properties": {
+            "all": {
+              "type": "boolean"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "old"
+          ],
+          "type": "object"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "trim_prefix": {
+          "type": "string"
+        },
+        "trim_suffix": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "properties": {
@@ -113,64 +156,16 @@
                       "additionalProperties": false,
                       "properties": {
                         "summary": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "replace": {
-                              "type": "string"
-                            },
-                            "remove": {
-                              "type": "boolean"
-                            },
-                            "suffix": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringTransformRule"
                         },
                         "description": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "replace": {
-                              "type": "string"
-                            },
-                            "remove": {
-                              "type": "boolean"
-                            },
-                            "suffix": {
-                              "type": "string"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringTransformRule"
                         },
                         "location": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "replace": {
-                              "type": "string"
-                            },
-                            "remove": {
-                              "type": "boolean"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringTransformRule"
                         },
                         "url": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "replace": {
-                              "type": "string"
-                            },
-                            "remove": {
-                              "type": "boolean"
-                            }
-                          },
-                          "type": "object"
+                          "$ref": "#/$defs/stringTransformRule"
                         }
                       },
                       "type": "object"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,6 +58,15 @@ config:
   #         transform:
   #           url:
   #             replace: "https://example.com/meeting"
+  #       - description: "Clean up event summaries"
+  #         transform:
+  #           summary:
+  #             trim_prefix: "Canceled: "
+  #             trim_suffix: " - tentative"
+  #             replace_text:
+  #               old: "sync"
+  #               new: "planning"
+  #               all: true
   #   - name: secrets
   #     feed_url_file: /run/secrets/url
   #     token_file: /run/secrets/token

--- a/filter.go
+++ b/filter.go
@@ -33,6 +33,9 @@ func (filter FilterConfig) compile() (Filter, error) {
 	if err != nil {
 		return Filter{}, err
 	}
+	if err := filter.Transform.validate(); err != nil {
+		return Filter{}, err
+	}
 
 	return Filter{
 		Description: filter.Description,
@@ -135,6 +138,25 @@ type EventTransformRules struct {
 	Description StringTransformRule `yaml:"description"`
 	Location    StringTransformRule `yaml:"location"`
 	URL         StringTransformRule `yaml:"url"`
+}
+
+func (rules EventTransformRules) validate() error {
+	stringTransforms := []struct {
+		name string
+		rule StringTransformRule
+	}{
+		{name: "summary", rule: rules.Summary},
+		{name: "description", rule: rules.Description},
+		{name: "location", rule: rules.Location},
+		{name: "url", rule: rules.URL},
+	}
+	for _, transform := range stringTransforms {
+		if err := transform.rule.validate(); err != nil {
+			return fmt.Errorf("%s: %w", transform.name, err)
+		}
+	}
+
+	return nil
 }
 
 type eventStringMatch struct {

--- a/filter_test.go
+++ b/filter_test.go
@@ -301,6 +301,31 @@ func TestFilterTransformEvent(t *testing.T) {
 				ics.ComponentPropertyUrl:         "https://example.com/original?tracked=true",
 			},
 		},
+		{
+			name: "rich string transforms fields",
+			transform: EventTransformRules{
+				Summary: StringTransformRule{
+					TrimPrefix:  "old ",
+					TrimSuffix:  " summary",
+					ReplaceText: ReplaceTextRule{Old: "original", New: "new"},
+				},
+				Description: StringTransformRule{
+					TrimPrefix: "old ",
+				},
+				Location: StringTransformRule{
+					TrimSuffix: " location",
+				},
+				URL: StringTransformRule{
+					ReplaceText: ReplaceTextRule{Old: "/original", New: "/new"},
+				},
+			},
+			want: map[ics.ComponentProperty]string{
+				ics.ComponentPropertySummary:     "new",
+				ics.ComponentPropertyDescription: "original description",
+				ics.ComponentPropertyLocation:    "original",
+				ics.ComponentPropertyUrl:         "https://example.com/new",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -324,6 +349,22 @@ func TestFilterTransformEvent(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFilterConfigCompileRejectsInvalidTransform(t *testing.T) {
+	_, err := (FilterConfig{
+		Transform: EventTransformRules{
+			Description: StringTransformRule{
+				ReplaceText: ReplaceTextRule{New: "new"},
+			},
+		},
+	}).compile()
+	if err == nil {
+		t.Fatal("compile() returned nil error")
+	}
+	if got, want := err.Error(), "description: replace_text.old must not be empty"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 }
 

--- a/string_rules.go
+++ b/string_rules.go
@@ -163,17 +163,41 @@ func (rule StringMatchRule) matchesString(data string) bool {
 
 // StringTransformRule defines changes for VEvent properties with string values
 type StringTransformRule struct {
-	Replace string `yaml:"replace"`
-	Remove  bool   `yaml:"remove"`
-	Prefix  string `yaml:"prefix"`
-	Suffix  string `yaml:"suffix"`
+	Replace     string          `yaml:"replace"`
+	Remove      bool            `yaml:"remove"`
+	TrimPrefix  string          `yaml:"trim_prefix"`
+	TrimSuffix  string          `yaml:"trim_suffix"`
+	ReplaceText ReplaceTextRule `yaml:"replace_text"`
+	Prefix      string          `yaml:"prefix"`
+	Suffix      string          `yaml:"suffix"`
+}
+
+type ReplaceTextRule struct {
+	Old string `yaml:"old"`
+	New string `yaml:"new"`
+	All bool   `yaml:"all"`
 }
 
 func (str StringTransformRule) hasActions() bool {
 	return str.Replace != "" ||
 		str.Remove ||
+		str.TrimPrefix != "" ||
+		str.TrimSuffix != "" ||
+		str.ReplaceText.hasActions() ||
 		str.Prefix != "" ||
 		str.Suffix != ""
+}
+
+func (str StringTransformRule) validate() error {
+	if str.ReplaceText.hasActions() && str.ReplaceText.Old == "" {
+		return fmt.Errorf("replace_text.old must not be empty")
+	}
+
+	return nil
+}
+
+func (rule ReplaceTextRule) hasActions() bool {
+	return rule.Old != "" || rule.New != "" || rule.All
 }
 
 func applyStringTransform(value string, rule StringTransformRule) string {
@@ -182,6 +206,19 @@ func applyStringTransform(value string, rule StringTransformRule) string {
 	}
 	if rule.Replace != "" {
 		return rule.Replace
+	}
+	if rule.TrimPrefix != "" {
+		value = strings.TrimPrefix(value, rule.TrimPrefix)
+	}
+	if rule.TrimSuffix != "" {
+		value = strings.TrimSuffix(value, rule.TrimSuffix)
+	}
+	if rule.ReplaceText.Old != "" {
+		n := 1
+		if rule.ReplaceText.All {
+			n = -1
+		}
+		value = strings.Replace(value, rule.ReplaceText.Old, rule.ReplaceText.New, n)
 	}
 	if rule.Prefix != "" {
 		value = rule.Prefix + value

--- a/string_rules_test.go
+++ b/string_rules_test.go
@@ -362,6 +362,31 @@ func TestStringTransformRuleHasActions(t *testing.T) {
 			rule: StringTransformRule{Suffix: " new"},
 			want: true,
 		},
+		{
+			name: "trim prefix action",
+			rule: StringTransformRule{TrimPrefix: "old "},
+			want: true,
+		},
+		{
+			name: "trim suffix action",
+			rule: StringTransformRule{TrimSuffix: " old"},
+			want: true,
+		},
+		{
+			name: "replace text action with old",
+			rule: StringTransformRule{ReplaceText: ReplaceTextRule{Old: "old"}},
+			want: true,
+		},
+		{
+			name: "replace text action with new",
+			rule: StringTransformRule{ReplaceText: ReplaceTextRule{New: "new"}},
+			want: true,
+		},
+		{
+			name: "replace text action with all",
+			rule: StringTransformRule{ReplaceText: ReplaceTextRule{All: true}},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -369,6 +394,44 @@ func TestStringTransformRuleHasActions(t *testing.T) {
 			got := tt.rule.hasActions()
 			if got != tt.want {
 				t.Fatalf("hasActions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringTransformRuleValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    StringTransformRule
+		wantErr bool
+	}{
+		{
+			name:    "empty rule",
+			rule:    StringTransformRule{},
+			wantErr: false,
+		},
+		{
+			name:    "replace text with old",
+			rule:    StringTransformRule{ReplaceText: ReplaceTextRule{Old: "old"}},
+			wantErr: false,
+		},
+		{
+			name:    "replace text with empty old and new value",
+			rule:    StringTransformRule{ReplaceText: ReplaceTextRule{New: "new"}},
+			wantErr: true,
+		},
+		{
+			name:    "replace text with empty old and all",
+			rule:    StringTransformRule{ReplaceText: ReplaceTextRule{All: true}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rule.validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -416,6 +479,62 @@ func TestApplyStringTransform(t *testing.T) {
 			value: "",
 			rule:  StringTransformRule{Suffix: "suffix"},
 			want:  "suffix",
+		},
+		{
+			name:  "trim_prefix removes matching prefix",
+			value: "prefix - calendar event",
+			rule:  StringTransformRule{TrimPrefix: "prefix - "},
+			want:  "calendar event",
+		},
+		{
+			name:  "trim_prefix leaves non-matching value",
+			value: "calendar event",
+			rule:  StringTransformRule{TrimPrefix: "prefix - "},
+			want:  "calendar event",
+		},
+		{
+			name:  "trim_suffix removes matching suffix",
+			value: "calendar event - suffix",
+			rule:  StringTransformRule{TrimSuffix: " - suffix"},
+			want:  "calendar event",
+		},
+		{
+			name:  "trim_suffix leaves non-matching value",
+			value: "calendar event",
+			rule:  StringTransformRule{TrimSuffix: " - suffix"},
+			want:  "calendar event",
+		},
+		{
+			name:  "replace_text replaces first occurrence",
+			value: "team event event",
+			rule: StringTransformRule{
+				ReplaceText: ReplaceTextRule{Old: "event", New: "shift"},
+			},
+			want: "team shift event",
+		},
+		{
+			name:  "replace_text replaces all occurrences",
+			value: "team event event",
+			rule: StringTransformRule{
+				ReplaceText: ReplaceTextRule{Old: "event", New: "shift", All: true},
+			},
+			want: "team shift shift",
+		},
+		{
+			name:  "new transforms compose before prefix and suffix",
+			value: "prefix - team event event - suffix",
+			rule: StringTransformRule{
+				TrimPrefix: "prefix - ",
+				TrimSuffix: " - suffix",
+				ReplaceText: ReplaceTextRule{
+					Old: "event",
+					New: "shift",
+					All: true,
+				},
+				Prefix: "[",
+				Suffix: "]",
+			},
+			want: "[team shift shift]",
 		},
 	}
 


### PR DESCRIPTION
- add richer string transforms:
    - `trim_prefix`
    - `trim_suffix`
    - `replace_text`
- preserve existing transform precedence:
    - remove still blanks the whole field and wins over other transforms
    - replace still replaces the whole field and wins over trim/partial/prefix/suffix transforms
- apply new transforms consistently to all string fields
- validate config at compile time: `replace_text.old` must be set and non-empty

Closes #48