### PR TITLE
feat: allow user_agent to modify request headers per calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ calendars:
     token: "changeme" # optional - token must be used to pull iCal feed if defined
     public: false # optional - must be true if token is blank or not defined
     feed_url: "https://my-upstream-calendar.url/feed.ics" # URL for the upstream iCal feed
+    user_agent: "ical-filter-proxy" # optional - override User-Agent sent to this upstream feed
     filters: # optional - if no filters defined the upstream calendar is proxied as parsed
       - description: "Remove an event based on a regex"
         remove: true # events matching this filter will be removed

--- a/calendar.go
+++ b/calendar.go
@@ -19,6 +19,7 @@ type CalendarConfig struct {
 	Public      bool           `yaml:"public"`
 	Token       string         `yaml:"token"`
 	TokenFile   string         `yaml:"token_file"`
+	UserAgent   string         `yaml:"user_agent"`
 	FeedURL     string         `yaml:"feed_url"`
 	FeedURLFile string         `yaml:"feed_url_file"`
 	Filters     []FilterConfig `yaml:"filters"`
@@ -36,6 +37,7 @@ type Calendar struct {
 	PublishName string
 	Public      bool
 	Token       string
+	UserAgent   string
 	FeedURL     string
 	Filters     []Filter
 }
@@ -60,6 +62,7 @@ func (config Config) Compile() (RuntimeConfig, error) {
 			PublishName: calendarConfig.PublishName,
 			Public:      calendarConfig.Public,
 			Token:       calendarConfig.Token,
+			UserAgent:   calendarConfig.UserAgent,
 			FeedURL:     calendarConfig.FeedURL,
 			Filters:     filters,
 		})
@@ -73,7 +76,7 @@ func (calendar Calendar) fetch(ctx context.Context) ([]byte, error) {
 
 	// get the iCal feed
 	slog.Debug("fetching upstream calendar", "calendar", calendar.Name, "url", redactURL(calendar.FeedURL))
-	feedData, err := fetchUpstreamCalendar(ctx, calendar.FeedURL)
+	feedData, err := fetchUpstreamCalendar(ctx, calendar.FeedURL, calendar.UserAgent)
 	if err != nil {
 		return nil, err
 	}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -189,6 +189,9 @@
               },
               "token_file": {
                 "type": "string"
+              },
+              "user_agent": {
+                "type": "string"
               }
             },
             "required": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -30,6 +30,7 @@ config:
   #   - name: outlook
   #     token: "changeme"
   #     feed_url: "https://outlook.office365.com/owa/calendar/.../reachcalendar.ics"
+  #     user_agent: "ical-filter-proxy"
   #     filters:
   #       - description: "Remove cancelled events"
   #         remove: true

--- a/config.go
+++ b/config.go
@@ -83,6 +83,7 @@ func loadConfig(file string, lookupEnv envLookupFunc) (Config, error) {
 		if !calendarConfig.Public && calendarConfig.Token == "" {
 			return Config{}, fmt.Errorf("calendar %q: private calendar must define token or token_file", calendarConfig.Name)
 		}
+		calendarConfig.UserAgent = strings.TrimSpace(calendarConfig.UserAgent)
 
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -250,6 +250,7 @@ func TestConfigCompile(t *testing.T) {
 				Public:      false,
 				Token:       "secret",
 				TokenFile:   "/run/secrets/token",
+				UserAgent:   "custom-calendar-client/1.0",
 				FeedURL:     "https://example.com/feed.ics",
 				FeedURLFile: "/run/secrets/feed-url",
 				Filters: []FilterConfig{
@@ -285,6 +286,9 @@ func TestConfigCompile(t *testing.T) {
 	}
 	if calendar.Token != "secret" {
 		t.Fatalf("Token = %q, want secret", calendar.Token)
+	}
+	if calendar.UserAgent != "custom-calendar-client/1.0" {
+		t.Fatalf("UserAgent = %q, want custom-calendar-client/1.0", calendar.UserAgent)
 	}
 	if calendar.FeedURL != "https://example.com/feed.ics" {
 		t.Fatalf("FeedURL = %q, want https://example.com/feed.ics", calendar.FeedURL)

--- a/upstream.go
+++ b/upstream.go
@@ -15,12 +15,12 @@ var upstreamHTTPClient = &http.Client{
 	Timeout: 15 * time.Second,
 }
 
-func fetchUpstreamCalendar(ctx context.Context, feedURL string) ([]byte, error) {
+func fetchUpstreamCalendar(ctx context.Context, feedURL string, userAgent string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "ical-filter-proxy/"+version)
+	req.Header.Set("User-Agent", upstreamUserAgent(userAgent))
 	req.Header.Set("Accept", "text/calendar, text/plain;q=0.8, */*;q=0.1")
 
 	resp, err := upstreamHTTPClient.Do(req)
@@ -44,6 +44,14 @@ func fetchUpstreamCalendar(ctx context.Context, feedURL string) ([]byte, error) 
 	}
 
 	return feedData, nil
+}
+
+func upstreamUserAgent(userAgent string) string {
+	if userAgent != "" {
+		return userAgent
+	}
+
+	return "ical-filter-proxy/" + version
 }
 
 func redactURL(rawURL string) string {

--- a/upstream_test.go
+++ b/upstream_test.go
@@ -24,12 +24,40 @@ func TestFetchUpstreamCalendarSuccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	got, err := fetchUpstreamCalendar(context.Background(), server.URL)
+	got, err := fetchUpstreamCalendar(context.Background(), server.URL, "")
 	if err != nil {
 		t.Fatalf("fetchUpstreamCalendar returned error: %v", err)
 	}
 	if string(got) != body {
 		t.Fatalf("body = %q, want %q", string(got), body)
+	}
+}
+
+func TestFetchUpstreamCalendarUsesCustomUserAgent(t *testing.T) {
+	body := "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != "custom-calendar-client/1.0" {
+			t.Fatalf("User-Agent = %q, want custom-calendar-client/1.0", got)
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	got, err := fetchUpstreamCalendar(context.Background(), server.URL, "custom-calendar-client/1.0")
+	if err != nil {
+		t.Fatalf("fetchUpstreamCalendar returned error: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body = %q, want %q", string(got), body)
+	}
+}
+
+func TestUpstreamUserAgent(t *testing.T) {
+	if got, want := upstreamUserAgent("custom-calendar-client/1.0"), "custom-calendar-client/1.0"; got != want {
+		t.Fatalf("upstreamUserAgent(custom) = %q, want %q", got, want)
+	}
+	if got, want := upstreamUserAgent(""), "ical-filter-proxy/"+version; got != want {
+		t.Fatalf("upstreamUserAgent(empty) = %q, want %q", got, want)
 	}
 }
 
@@ -39,7 +67,7 @@ func TestFetchUpstreamCalendarRejectsNonSuccessStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := fetchUpstreamCalendar(context.Background(), server.URL)
+	_, err := fetchUpstreamCalendar(context.Background(), server.URL, "")
 	if err == nil {
 		t.Fatal("fetchUpstreamCalendar returned nil error")
 	}
@@ -54,7 +82,7 @@ func TestFetchUpstreamCalendarRejectsOversizedBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := fetchUpstreamCalendar(context.Background(), server.URL)
+	_, err := fetchUpstreamCalendar(context.Background(), server.URL, "")
 	if err == nil {
 		t.Fatal("fetchUpstreamCalendar returned nil error")
 	}
@@ -72,7 +100,7 @@ func TestFetchUpstreamCalendarUsesContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := fetchUpstreamCalendar(ctx, server.URL)
+	_, err := fetchUpstreamCalendar(ctx, server.URL, "")
 	if err == nil {
 		t.Fatal("fetchUpstreamCalendar returned nil error")
 	}


### PR DESCRIPTION
Add ability to customize User-Agent headers used for upstream calendar fetch
- add `user_agent` to calendar config settings
- default behavior remains `ical-filter-proxy/<version>` when unset

Closes #32
