### PR TITLE
ci: refresh Nix vendor hash in Renovate updates

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,6 +6,9 @@ on:
       - "*"
     paths:
       - ".github/workflows/nix.yml"
+      - "scripts/update-vendor-hash"
+      - "scripts/test_update_vendor_hash.py"
+      - "renovate.json"
       - "flake.lock"
       - "flake.nix"
       - "go.mod"
@@ -15,6 +18,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/nix.yml"
+      - "scripts/update-vendor-hash"
+      - "scripts/test_update_vendor_hash.py"
+      - "renovate.json"
       - "flake.lock"
       - "flake.nix"
       - "go.mod"
@@ -39,5 +45,20 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - name: Test vendor hash updater
+        run: |
+          python3 scripts/test_update_vendor_hash.py
+          ./scripts/update-vendor-hash
+          git diff --exit-code -- flake.nix flake.lock
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+          path = Path("flake.nix")
+          path.write_text(re.sub(r'vendorHash = "[^"]+"',
+                                'vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="',
+                                path.read_text()))
+          PY
+          ./scripts/update-vendor-hash
+          git diff --exit-code -- flake.nix flake.lock
       - name: Check flake
         run: nix flake check --print-build-logs

--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,15 @@
       ]
     },
     {
+      "description": "Refresh Nix vendorHash after Go or flake input updates",
+      "matchManagers": ["gomod", "nix"],
+      "postUpgradeTasks": {
+        "commands": ["./scripts/update-vendor-hash"],
+        "fileFilters": ["flake.nix"],
+        "executionMode": "branch"
+      }
+    },
+    {
       "description": "Group docs npm patch and minor updates",
       "matchManagers": [
         "npm"

--- a/scripts/test_update_vendor_hash.py
+++ b/scripts/test_update_vendor_hash.py
@@ -1,0 +1,62 @@
+"""Updater unit tests; Nix integration is exercised by the Nix workflow."""
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+class UpdaterTests(unittest.TestCase):
+    def test_extract_only_vendor_derivation_hash(self):
+        path = Path(__file__).with_name("update-vendor-hash")
+        self.assertTrue(path.exists(), "vendor-hash updater is missing")
+        loader = importlib.machinery.SourceFileLoader("updater", str(path))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        assert spec is not None
+        updater = importlib.util.module_from_spec(spec)
+        loader.exec_module(updater)
+        digest = "sha256-EMpIXQjZdkxP1lx2Zu4fWojXLtb4JlJZ+JUBn5z4yYY="
+        log = "error: hash mismatch in fixed-output derivation '/nix/store/abc-ical-filter-proxy-dev-go-modules.drv':\n  specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n  got:    " + digest
+        self.assertEqual(updater.extract_hash(log), digest)
+        with self.assertRaises(ValueError):
+            updater.extract_hash(log.replace("ical-filter-proxy-dev-go-modules", "unrelated"))
+        with self.assertRaises(ValueError):
+            updater.extract_hash("error: network unavailable")
+        with self.assertRaises(ValueError):
+            updater.extract_hash(log + "\n" + log)
+
+
+    def test_update_verifies_before_writing(self):
+        import subprocess
+        import tempfile
+        from unittest.mock import patch
+        loader = importlib.machinery.SourceFileLoader(
+            "updater", str(Path(__file__).with_name("update-vendor-hash")))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        assert spec is not None
+        updater = importlib.util.module_from_spec(spec)
+        loader.exec_module(updater)
+        self.assertTrue(hasattr(updater, "update"), "update operation is missing")
+        digest = "sha256-EMpIXQjZdkxP1lx2Zu4fWojXLtb4JlJZ+JUBn5z4yYY="
+        original = 'vendorHash = "sha256-OKOfPkssluK9uWE8BLZ9iyVpC1aLvQqzm6NyRyUYQY0=";\n'
+        log = "hash mismatch in fixed-output derivation '/nix/store/abc-ical-filter-proxy-dev-go-modules.drv':\n specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n got: " + digest
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            flake = root / "flake.nix"
+            flake.write_text(original)
+            (root / "flake.lock").write_text("{}")
+            for verified in (False, True):
+                flake.write_text(original)
+                responses = [subprocess.CompletedProcess([], 1, log),
+                             subprocess.CompletedProcess([], 0 if verified else 1, "verification")]
+                with patch.object(updater.subprocess, "run", side_effect=responses):
+                    if verified:
+                        updater.update(root)
+                        self.assertIn(digest, flake.read_text())
+                    else:
+                        with self.assertRaises(RuntimeError):
+                            updater.update(root)
+                        self.assertEqual(flake.read_text(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update-vendor-hash
+++ b/scripts/update-vendor-hash
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Refresh the locked default package's vendorHash; invoke without arguments."""
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def extract_hash(log):
+    matches = re.findall(
+        r"hash mismatch in fixed-output derivation '[^'\n]*/[^/'\n]*"
+        r"ical-filter-proxy-[^/'\n]*-go-modules\.drv':\s*"
+        r"specified:\s*sha256-[A-Za-z0-9+/]{43}=\s*"
+        r"got:\s*(sha256-[A-Za-z0-9+/]{43}=)",
+        log,
+    )
+    if len(matches) != 1:
+        raise ValueError("expected exactly one vendor derivation hash mismatch")
+    return matches[0]
+
+
+HASH = re.compile(r'(vendorHash\s*=\s*")(sha256-[A-Za-z0-9+/]{43}=)("\s*;)')
+FAKE_HASH = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+def update(root):
+    flake = root / "flake.nix"
+    original = flake.read_text()
+    if len(HASH.findall(original)) != 1:
+        raise ValueError("expected exactly one literal sha256 vendorHash")
+    if not (root / "flake.lock").is_file():
+        raise ValueError("flake.lock is required")
+    # Never leave a fake hash in the worktree, even after interruption/failure.
+    with tempfile.TemporaryDirectory(prefix="ical-vendor-") as directory:
+        source = Path(directory) / "source"
+        shutil.copytree(root, source, ignore=shutil.ignore_patterns(
+            ".git", "__pycache__", "result", "result-*", ".venv", "node_modules"))
+        scratch = source / "flake.nix"
+        scratch.write_text(HASH.sub(lambda m: m[1] + FAKE_HASH + m[3], original))
+        expression = (
+            "let f = builtins.getFlake " + json.dumps(str(source)) + "; "
+            "in f.packages.${builtins.currentSystem}.default.goModules"
+        )
+        command = ["nix", "--extra-experimental-features", "nix-command flakes",
+                   "build", "--impure", "--no-link", "--no-write-lock-file",
+                   "--print-build-logs", "--expr", expression]
+        result = subprocess.run(command, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, text=True)
+        if result.returncode == 0:
+            raise RuntimeError("fake vendor hash unexpectedly built successfully")
+        try:
+            digest = extract_hash(result.stdout)
+        except ValueError:
+            print(result.stdout, file=sys.stderr)
+            raise
+        updated = HASH.sub(lambda m: m[1] + digest + m[3], original)
+        scratch.write_text(updated)
+        result = subprocess.run(command, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, text=True)
+        if result.returncode:
+            print(result.stdout, file=sys.stderr)
+            raise RuntimeError("vendor derivation verification failed; flake.nix unchanged")
+    if flake.read_text() != original:
+        raise RuntimeError("flake.nix changed while updater was running")
+    if updated != original:
+        flake.write_text(updated)
+        print("Updated vendorHash to " + digest)
+    else:
+        print("vendorHash is already current")
+
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) != 1:
+            raise ValueError("invoke without arguments")
+        update(Path(__file__).resolve().parent.parent)
+    except (OSError, ValueError, RuntimeError) as error:
+        sys.exit(str(error))


### PR DESCRIPTION
## Summary
- Add executable `./scripts/update-vendor-hash` (Python 3 + Nix), building the locked default package's actual `goModules` derivation in a temporary source copy.
- Force recalculation with a fake hash, accept only a single matching ical vendor-derivation mismatch, then rebuild with the calculated hash before touching the worktree. Unrelated errors fail; no fake hash is left in the checkout.
- Run once per Renovate branch for `gomod` and `nix` updates, collecting only `flake.nix`. Preserve `gomodTidy` and existing grouping.
- Extend the existing Nix workflow with parser/failure-safety tests plus real unchanged-hash and deliberately stale-hash integration checks. No monorepo changes or extra workflows.

## Validation
Head: `b5de8afce4f9e9dff881de68affe484534ce3674`.
- Python unit tests passed (test-first): targeted mismatch parsing, rejection of unrelated/ambiguous errors, verification-before-write and failure preservation.
- Renovate 44.79.5 config validator passed (local Node 26 emitted an engine warning; pinned Renovate expects Node 24).
- `git diff --check` passed.
- [Nix CI passed](https://github.com/yungwood/ical-filter-proxy/actions/runs/34567658180/job/103162964103): real locked vendor derivation rebuild, unchanged-hash idempotence, deliberately stale-hash repair, unchanged lockfile, and full `nix flake check`.
- [actionlint passed](https://github.com/yungwood/ical-filter-proxy/actions/runs/34567658207/job/103162964031).
- Local Nix was unavailable and local Docker daemon inaccessible; actual Nix execution was verified in GitHub CI, not fabricated from mocks.

## Draft / runner prerequisite
The self-hosted Renovate full image uses a relocated Nix store which cannot consume the standard `/nix/store` binary cache. GitHub CI proves the updater works with canonical Nix, not that the real locked nixpkgs/vendor build is practical in that runner. Keep draft until the actual runner has a verified usable store/cache strategy (and Python 3). No runner configuration changes are bundled here.

Admin command permission for executable `./scripts/...` is already prepared in the monorepo. Repo scripts run with the runner's access; the command allowlist is not a sandbox. No new bot credentials or Actions write permissions are required.

—
Posted by coding agent on behalf of @yungwood.