### PR TITLE
fix(docs): silence TypeScript 6 baseUrl deprecation

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
   },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary
- Add `compilerOptions.ignoreDeprecations: "6.0"` to the docs tsconfig, preserving Docusaurus baseUrl behavior.
- Remove the stale comment claiming tsconfig is not used in compilation: CI runs `tsc` against it.
- Existing Renovate TypeScript `allowedVersions: "<7.0.0"` remains unchanged.

## Merge order
**Targets the Renovate branch for #81**, not main. Merge this fix into `renovate/major-docs-npm-major`, then merge #81 after its checks pass. TypeScript 5.9 on main rejects `ignoreDeprecations: "6.0"` with TS5103, so this cannot safely land before the TypeScript 6 upgrade. The PR delta is only `docs/tsconfig.json`; it does not duplicate the dependency update.

## Validation
- Reproduced TS5101 using TypeScript 6.0.3 before the fix.
- Confirmed the option causes TS5103 under main's TypeScript 5.9; chose a stacked PR to avoid that regression.
- On #81's exact dependency lockfile: `npm ci`, `npm run typecheck`, and `npm run build` passed after the fix.
- `git diff --check` passed. GitHub CI pending.

This is a temporary compatibility suppression, not removal of baseUrl; revisit when Docusaurus supports TypeScript 7.

—
Posted by coding agent on behalf of @yungwood.