### PR TITLE
chore(renovate): group Go minor and major updates separately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,29 @@
       ]
     },
     {
+      "description": "Group Go module patch and minor updates",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "Go minor and patch dependencies",
+      "groupSlug": "go-minor-patch"
+    },
+    {
+      "description": "Group Go module major updates",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "Go major dependencies",
+      "groupSlug": "go-major"
+    },
+    {
       "description": "Refresh Nix vendorHash after Go or flake input updates",
       "matchManagers": ["gomod", "nix"],
       "postUpgradeTasks": {


### PR DESCRIPTION
## Summary
- Group `gomod` minor and patch updates into `Go minor and patch dependencies`.
- Group `gomod` major updates separately into `Go major dependencies`.
- Docs npm dependencies already have equivalent minor/patch and major groups; leave those unchanged.
- Preserve GitHub Actions grouping, `gomodTidy`, branch-level Nix vendorHash updater, and TypeScript `<7.0.0` restriction. No automerge changes.

## Validation
- Renovate 44.79.5 config validator passed.
- `git diff --check` passed.
- Configuration-only change; actual grouped branches will be generated on a subsequent Renovate run after merge. Existing dependency PRs were not modified or closed.

—
Posted by coding agent on behalf of @yungwood.